### PR TITLE
Memory fix

### DIFF
--- a/src/dvpio/read/image/czi.py
+++ b/src/dvpio/read/image/czi.py
@@ -2,14 +2,13 @@ from collections.abc import Mapping
 from enum import Enum
 from typing import Any
 
-import dask.array as da
 import numpy as np
 from dask import delayed
 from numpy.typing import NDArray
 from pylibCZIrw import czi as pyczi
 from spatialdata.models import Image2DModel
 
-from ._utils import _assemble_delayed, _chunk_factory, _create_tiles
+from ._utils import _assemble, _chunk_factory, _create_tiles
 
 
 class CZIPixelType(Enum):
@@ -183,6 +182,7 @@ def read_czi(
                 _get_img,
                 slide=czidoc_r,
                 coords=chunk_coords,
+                n_channel=1,
                 channel=c,
                 timepoint=timepoint,
                 z_stack=z_stack,
@@ -194,18 +194,13 @@ def read_czi(
             _get_img,
             slide=czidoc_r,
             coords=chunk_coords,
+            n_channel=sum(channel_dim),
             channel=channels,
             timepoint=timepoint,
             z_stack=z_stack,
         )
 
-    array_ = _assemble_delayed(chunks)
-
-    array = da.from_delayed(
-        array_,
-        shape=(sum(channel_dim), width, height),
-        dtype=pixel_spec.dtype,
-    )
+    array = _assemble(chunks)
 
     return Image2DModel.parse(
         array,

--- a/src/dvpio/read/image/openslide.py
+++ b/src/dvpio/read/image/openslide.py
@@ -1,13 +1,12 @@
 """Reader for Whole Slide Images"""
 
-import dask.array as da
 import numpy as np
 import openslide
 from dask import delayed
 from numpy.typing import NDArray
 from spatialdata.models import Image2DModel
 
-from ._utils import _assemble_delayed, _chunk_factory, _create_tiles
+from ._utils import _assemble, _chunk_factory, _create_tiles
 
 
 @delayed
@@ -101,11 +100,11 @@ def read_openslide(path: str, chunk_size: tuple[int, int] = (10000, 10000), pyra
     # Define coordinates for chunkwise loading of the slide
     chunk_coords = _create_tiles(dimensions=dimensions, tile_size=chunk_size, min_coordinates=(0, 0))
 
-    chunks = _chunk_factory(_get_img, slide=slide, coords=chunk_coords, level=0)
+    # Load chunkwise (parallelized with dask.delayed)
+    chunks = _chunk_factory(_get_img, slide=slide, coords=chunk_coords, n_channel=4, level=0)
 
     # Assemble into a single dask array
-    array_ = _assemble_delayed(chunks)
-    array = da.from_delayed(array_, shape=(4, *dimensions[::-1]), dtype=np.uint8).rechunk()
+    array = _assemble(chunks)
 
     return Image2DModel.parse(
         array,

--- a/tests/read/image/test_czi.py
+++ b/tests/read/image/test_czi.py
@@ -8,7 +8,7 @@ from dvpio.read.image import read_czi
     ("dataset", "xmin", "ymin", "width", "height"),
     [
         # RGB
-        # ("./data/zeiss/zeiss/kabatnik2023_20211129_C1.czi", -170000, 40000, 10000, 10000),
+        ("./data/zeiss/zeiss/kabatnik2023_20211129_C1.czi", -170000, 40000, 10000, 10000),
         # Multichannel
         ("./data/zeiss/zeiss/zeiss_multi-channel.czi", 0, 0, 1000, 1000),
     ],

--- a/tests/read/image/test_openslide.py
+++ b/tests/read/image/test_openslide.py
@@ -1,5 +1,3 @@
-import sys
-
 import numpy as np
 import openslide
 import pytest
@@ -7,7 +5,7 @@ import pytest
 from dvpio.read.image import read_openslide
 
 
-@pytest.mark.skipif(sys.platform != "darwin", reason="Tests fail online due to limited resources")
+# @pytest.mark.skipif(sys.platform != "darwin", reason="Tests fail online due to limited resources")
 @pytest.mark.parametrize(
     ("dataset", "xmin", "ymin", "xmax", "ymax"),
     [

--- a/tests/read/image/test_utils.py
+++ b/tests/read/image/test_utils.py
@@ -3,6 +3,7 @@ from typing import Any
 import dask.array as da
 import numpy as np
 import pytest
+from dask import delayed
 from numpy.typing import NDArray
 
 from dvpio.read.image._utils import _chunk_factory, _create_tiles
@@ -75,13 +76,14 @@ def test_chunk_factory(
 ) -> None:
     """Test if tiles can be assembled to dask array"""
 
+    @delayed
     def func(slide: Any, coords: Any, size: tuple[int]) -> NDArray[np.int_]:
         """Create arrays in shape of tiles"""
-        return np.zeros(shape=size)
+        return da.zeros(shape=size)
 
     coords = _create_tiles(dimensions=dimensions, tile_size=tile_size, min_coordinates=min_coordinates)
 
-    tiles_ = _chunk_factory(func, slide=None, coords=coords).compute()
+    tiles_ = _chunk_factory(func, slide=None, coords=coords, n_channel=1)
     tiles = da.block(tiles_)
 
-    assert tiles.shape == dimensions
+    assert tiles.shape == (1, *dimensions)


### PR DESCRIPTION
Changed logic of image Dask Array creation 

Addresses issues in #4 

Before:
1. `_chunk_factory`: Read in tiles as numpy arrays (delayed)
2. Assemble chunks (delayed)
3. Create array (end of delayed)
This led to the issue that tiles were loaded into memory and persisted, leading to extremely high memory utilization 


Now:
1. Create nested list of `dask.array` right away  in `_chunk_factory`. Use delayed paradigm for parallelization
2. Assemble chunks 
This led to a significant speed up and hopefully to better memory management. 