### PR TITLE
[Fix] Docs build

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -8,6 +8,9 @@ sphinx:
   configuration: docs/conf.py
   # disable this for more lenient docs builds
   fail_on_warning: true
+commands:
+  pre_build:
+    - sudo apt-get update && sudo apt-get install -y libssh2-1 libssh2-1-dev
 python:
   install:
     - method: pip

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,10 +14,9 @@ maintainers = [
 authors = [
   { name = "Lucas Diedrich" },
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 classifiers = [
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,9 +14,10 @@ maintainers = [
 authors = [
   { name = "Lucas Diedrich" },
 ]
-requires-python = ">=3.10"
+requires-python = ">=3.9"
 classifiers = [
   "Programming Language :: Python :: 3 :: Only",
+  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",


### PR DESCRIPTION
Addresses #52 Which failed due to a missing dependency (`libssh2`)