### PR TITLE
Add glob string support for `read_custom`

### DIFF
--- a/src/dvpio/read/image/custom.py
+++ b/src/dvpio/read/image/custom.py
@@ -33,8 +33,6 @@ def read_custom(
     -------
     :class:`spatialdata.models.Image2DModel`
     """
-    # Per default, reads a glob string and has 4 dimensions
-    # Remove 0th dimension as we currently do not support globstrings
-    img = daimread(path, imread=imread).squeeze(0)
+    img = daimread(path, imread=imread)
 
     return Image2DModel.parse(img, **kwargs)

--- a/tests/read/image/test_custom.py
+++ b/tests/read/image/test_custom.py
@@ -4,7 +4,9 @@ from tifffile import imread as tiffread
 from dvpio.read.image import read_custom
 
 
-@pytest.mark.parametrize(["filename"], [["./data/blobs/blobs/images/binary-blobs.tiff"]])
+@pytest.mark.parametrize(
+    ["filename"], [["./data/blobs/blobs/images/binary-blobs.tiff"], ["./data/blobs/blobs/images/binary-blobs*.tiff"]]
+)
 def test_custom(filename: str) -> None:
     # TODO Create a more elegant solution
     img = read_custom(filename, imread=lambda path: tiffread(path).squeeze(), dims=("c", "y", "x"))

--- a/tests/read/image/test_custom.py
+++ b/tests/read/image/test_custom.py
@@ -6,7 +6,8 @@ from dvpio.read.image import read_custom
 
 @pytest.mark.parametrize(["filename"], [["./data/blobs/blobs/images/binary-blobs.tiff"]])
 def test_custom(filename: str) -> None:
-    img = read_custom(filename, dims=("c", "y", "x"))
+    # TODO Create a more elegant solution
+    img = read_custom(filename, imread=lambda path: tiffread(path).squeeze(), dims=("c", "y", "x"))
 
     img_groundtruth = tiffread(filename)
 


### PR DESCRIPTION
Adds support to read custom image files with glob strings by removing the `squeeze(0)` argument, extending its functionality to the full functionality of the wrapped `dask.array.image.imread` function. This adds flexibility to the `read_custom` function and makes it possible to aggregate multiple fluroscence channels at once in a single `Image2DModel` object.

Currently, the test cases of this function are somewhat limited and it should be refactored at some point. It is expected that unexpected user behavior breaks this function. 