### PR TITLE
[Fix] Hotfix for incorrect dtyping in CZI grayscale range

### DIFF
--- a/src/dvpio/read/image/czi.py
+++ b/src/dvpio/read/image/czi.py
@@ -19,10 +19,10 @@ class CZIPixelType(Enum):
     Documented pixel types https://zeiss.github.io/libczi/accessors.html
     """
 
-    Gray8 = (1, np.uint8, None)
+    Gray8 = (1, np.uint16, None)
     Gray16 = (1, np.uint16, None)
     Gray32Float = (1, np.float32, None)
-    Bgr24 = (3, np.uint8, ["r", "g", "b"])
+    Bgr24 = (3, np.uint16, ["r", "g", "b"])
     Bgr48 = (3, np.uint16, ["r", "g", "b"])
     Bgr96Float = (3, np.float32, ["r", "g", "b"])
     Invalid = (np.nan, np.nan, np.nan)


### PR DESCRIPTION
CZI gray8 pixeltype is supposed to represent pixels in 8-bitrange (see here: https://zeiss.github.io/libczi/namespacelib_c_z_i.html#abf8ce12ab88b06c8b3b47efbb5e2e834ac8cfe3d00282445878661f32adca48ef). However, in real-world data, Gray8 images can also be represented in 16-bit range:

```json
{
....
   'BitCountRange': '16',
   'PixelType': 'Gray8'
....
}
```
Change default pixeltypes to uint16/float32 to prevent overflow. 