### PR TITLE
Metadata Parsing | CZI

### DIFF
--- a/src/dvpio/read/image/_metadata.py
+++ b/src/dvpio/read/image/_metadata.py
@@ -8,7 +8,7 @@ def _get_value_from_nested_dict(nested_dict: dict, keys: list, default_return_va
     """Get a specific value from a nested dictionary"""
     for key in keys[:-1]:
         if not isinstance(nested_dict, dict):
-            raise ValueError(f"Returned type of key {key} in nested dict is not expected dict but {type(dict)}")
+            raise ValueError(f"Returned type of key {key} in nested dict is not expected dict but {type(nested_dict)}")
         nested_dict = nested_dict.get(key, {})
 
     return nested_dict.get(keys[-1], default_return_value)

--- a/src/dvpio/read/image/_metadata.py
+++ b/src/dvpio/read/image/_metadata.py
@@ -9,7 +9,7 @@ class ImageMetadata(BaseModel, ABC):
 
     @property
     @abstractmethod
-    def magnification(self) -> int | None:
+    def objective_nominal_magnification(self) -> int | None:
         raise NotImplementedError
 
     @property
@@ -160,7 +160,7 @@ class CZIImageMetadata(ImageMetadata):
     @computed_field
     @property
     def objective_name(self) -> str | None:
-        """Utilized objective name. Required to infer magnification
+        """Utilized objective name. Required to infer objective_nominal_magnification
 
         Note
         ----
@@ -177,13 +177,13 @@ class CZIImageMetadata(ImageMetadata):
 
     @computed_field
     @property
-    def magnification(self) -> float | None:
-        """Utilized magnification
+    def objective_nominal_magnification(self) -> float | None:
+        """Utilized objective_nominal_magnification
 
         Note
         ----
-        Given the utilized objective the utilized magnification can be extracted
-        from the metadata on all available Objectives. The magnification of an objective
+        Given the utilized objective the utilized objective_nominal_magnification can be extracted
+        from the metadata on all available Objectives. The objective_nominal_magnification of an objective
         is given as `NominalMagnification` field.
         """
         objectives = (
@@ -197,11 +197,11 @@ class CZIImageMetadata(ImageMetadata):
 
         if isinstance(objectives, dict):
             objectives = [objectives]
-        magnification = None
+        objective_nominal_magnification = None
         for objective in objectives:
             if objective.get("@Name") == self.objective_name:
-                magnification = objective.get("NominalMagnification")
-        return float(magnification) if magnification else None
+                objective_nominal_magnification = objective.get("NominalMagnification")
+        return float(objective_nominal_magnification) if objective_nominal_magnification else None
 
     @classmethod
     def from_file(cls, path: str) -> BaseModel:

--- a/src/dvpio/read/image/_metadata.py
+++ b/src/dvpio/read/image/_metadata.py
@@ -108,6 +108,50 @@ class CZIImageMetadata(ImageMetadata):
         """
         return [channel.get("@Name", str(idx)) for idx, channel in enumerate(self.channel_info)]
 
+    @computed_field
+    @property
+    def mpp(self) -> dict[str, dict[str, str]]:
+        """Parse pixel resolution from slide image
+
+        Note
+        ----
+        Pixel resolution is stored in `Distance` field and always specified in meters per pixel
+        """
+        mpp = (
+            self.metadata.get("ImageDocument", {})
+            .get("Metadata", {})
+            .get("Scaling", {})
+            .get("Items", {})
+            .get("Distance", [])
+        )
+
+        # Transpose list of dictionaries to dictionary with dimension name (X, Y, Z)
+        # as keys and data as values
+        mpp = {dim.get("@Id", str(idx)): dim for idx, dim in enumerate(mpp)}
+
+        return mpp
+
+    @computed_field
+    @property
+    def mpp_x(self) -> float | None:
+        """Return resolution in X dimension in [meters per pixel]"""
+        mpp_x = self.mpp.get("X", {}).get("Value", None)
+        return float(mpp_x) if mpp_x else None
+
+    @computed_field
+    @property
+    def mpp_y(self) -> float | None:
+        """Resolution in Y dimension in [meters per pixel]"""
+        mpp_y = self.mpp.get("Y", {}).get("Value", None)
+        return float(mpp_y) if mpp_y else None
+
+    @computed_field
+    @property
+    def mpp_z(self) -> float | None:
+        """Resolution in Z dimension in [meters per pixel]"""
+        mpp_z = self.mpp.get("Z", {}).get("Value", None)
+        return float(mpp_z) if mpp_z else None
+
     @classmethod
     def from_file(cls, path: str) -> BaseModel:
         """Parse metadata from file path

--- a/src/dvpio/read/image/_metadata.py
+++ b/src/dvpio/read/image/_metadata.py
@@ -45,3 +45,23 @@ class ImageMetadata(BaseModel, ABC):
 
 class CZIImageMetadata(ImageMetadata):
     metadata: dict[str, Any]
+
+    @classmethod
+    def from_file(cls, path: str) -> BaseModel:
+        """Parse metadata from file path
+
+        Parameters
+        ----------
+        path
+            Path to `.czi` file.
+
+        Returns
+        -------
+        Parsed metadata as pydantic model
+        """
+        from pylibCZIrw.czi import open_czi
+
+        with open_czi(path) as czi:
+            metadata = czi.metadata
+
+        return cls(metadata=metadata)

--- a/src/dvpio/read/image/_metadata.py
+++ b/src/dvpio/read/image/_metadata.py
@@ -10,36 +10,49 @@ class ImageMetadata(BaseModel, ABC):
     @property
     @abstractmethod
     def objective_nominal_magnification(self) -> int | None:
+        """Nominal magnification of the microscope objective
+
+        Note
+        ----
+        This value does not consider the magnifications by additional optical elements
+        in the specific microscopy setup
+        """
         raise NotImplementedError
 
     @property
     @abstractmethod
     def mpp_x(self) -> float:
+        """Resolution of the image in meters per pixel along x-axis"""
         raise NotImplementedError
 
     @property
     @abstractmethod
     def mpp_y(self) -> float:
+        """Resolution of the image in meters per pixel along y-axis"""
         raise NotImplementedError
 
     @property
     @abstractmethod
     def mpp_z(self) -> float:
+        """Resolution of the image in meters per pixel along z-axis"""
         raise NotImplementedError
 
     @property
     @abstractmethod
     def channel_names(self) -> list[str] | None:
+        """Names of the microscopy channels"""
         raise NotImplementedError
 
     @property
     @abstractmethod
     def image_type(self) -> str:
+        """Indicator of the original image format/microscopy vendor"""
         raise NotImplementedError
 
     @classmethod
     @abstractmethod
     def from_file(path: str):
+        """Load metadata from microscopy image in path"""
         raise NotImplementedError
 
 

--- a/src/dvpio/read/image/_metadata.py
+++ b/src/dvpio/read/image/_metadata.py
@@ -1,0 +1,42 @@
+from abc import ABC, abstractmethod
+
+from pydantic import BaseModel
+
+
+class ImageMetadata(BaseModel, ABC):
+    metadata: dict[str, dict | list | str]
+
+    @property
+    @abstractmethod
+    def magnification(self) -> int | None:
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def mpp_x(self) -> float:
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def mpp_y(self) -> float:
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def mpp_z(self) -> float:
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def channel_names(self) -> list[str] | None:
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def image_type(self) -> str:
+        raise NotImplementedError
+
+    @classmethod
+    @abstractmethod
+    def from_file(path: str):
+        raise NotImplementedError

--- a/src/dvpio/read/image/_metadata.py
+++ b/src/dvpio/read/image/_metadata.py
@@ -69,7 +69,7 @@ class ImageMetadata(BaseModel, ABC):
 class CZIImageMetadata(ImageMetadata):
     metadata: dict[str, Any]
 
-    channel_info_path: ClassVar = [
+    channel_info_path: ClassVar = (
         "ImageDocument",
         "Metadata",
         "Information",
@@ -77,17 +77,17 @@ class CZIImageMetadata(ImageMetadata):
         "Dimensions",
         "Channels",
         "Channel",
-    ]
-    mpp_path: ClassVar = ["ImageDocument", "Metadata", "Scaling", "Items", "Distance"]
-    objective_name_path: ClassVar = ["ImageDocument", "Metadata", "Scaling", "AutoScaling", "ObjectiveName"]
-    objective_nominal_magnification_path: ClassVar = [
+    )
+    mpp_path: ClassVar = ("ImageDocument", "Metadata", "Scaling", "Items", "Distance")
+    objective_name_path: ClassVar = ("ImageDocument", "Metadata", "Scaling", "AutoScaling", "ObjectiveName")
+    objective_nominal_magnification_path: ClassVar = (
         "ImageDocument",
         "Metadata",
         "Information",
         "Instrument",
         "Objectives",
         "Objective",
-    ]
+    )
 
     @property
     def image_type(self) -> str:

--- a/src/dvpio/read/image/_metadata.py
+++ b/src/dvpio/read/image/_metadata.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 from typing import Any
 
-from pydantic import BaseModel, computed_field
+from pydantic import BaseModel
 
 
 class ImageMetadata(BaseModel, ABC):
@@ -59,7 +59,6 @@ class ImageMetadata(BaseModel, ABC):
 class CZIImageMetadata(ImageMetadata):
     metadata: dict[str, Any]
 
-    @computed_field
     @property
     def image_type(self) -> str:
         return "czi"
@@ -70,7 +69,6 @@ class CZIImageMetadata(ImageMetadata):
             return
         return int(channel_name.replace("Channel:", ""))
 
-    @computed_field
     @property
     def _channel_info(self) -> list[dict[str, str]]:
         """Obtain channel metadata from CZI metadata file
@@ -97,7 +95,6 @@ class CZIImageMetadata(ImageMetadata):
 
         return channels or []
 
-    @computed_field
     @property
     def channel_id(self) -> list[int]:
         """Parse channel metadata to list of channel ids
@@ -109,7 +106,6 @@ class CZIImageMetadata(ImageMetadata):
         """
         return [self._parse_channel_id(channel.get("@Id")) for channel in self._channel_info]
 
-    @computed_field
     @property
     def channel_names(self) -> list[str]:
         """Parse channel metadata to list of channel ids
@@ -126,7 +122,6 @@ class CZIImageMetadata(ImageMetadata):
         """
         return [channel.get("@Name", str(idx)) for idx, channel in enumerate(self._channel_info)]
 
-    @computed_field
     @property
     def _mpp(self) -> dict[str, dict[str, str]]:
         """Parse pixel resolution from slide image
@@ -149,28 +144,24 @@ class CZIImageMetadata(ImageMetadata):
 
         return mpp
 
-    @computed_field
     @property
     def mpp_x(self) -> float | None:
         """Return resolution in X dimension in [meters per pixel]"""
         mpp_x = self._mpp.get("X", {}).get("Value", None)
         return float(mpp_x) if mpp_x else None
 
-    @computed_field
     @property
     def mpp_y(self) -> float | None:
         """Resolution in Y dimension in [meters per pixel]"""
         mpp_y = self._mpp.get("Y", {}).get("Value", None)
         return float(mpp_y) if mpp_y else None
 
-    @computed_field
     @property
     def mpp_z(self) -> float | None:
         """Resolution in Z dimension in [meters per pixel]"""
         mpp_z = self._mpp.get("Z", {}).get("Value", None)
         return float(mpp_z) if mpp_z else None
 
-    @computed_field
     @property
     def objective_name(self) -> str | None:
         """Utilized objective name. Required to infer objective_nominal_magnification
@@ -188,7 +179,6 @@ class CZIImageMetadata(ImageMetadata):
             .get("ObjectiveName")
         )
 
-    @computed_field
     @property
     def objective_nominal_magnification(self) -> float | None:
         """Utilized objective_nominal_magnification

--- a/src/dvpio/read/image/_metadata.py
+++ b/src/dvpio/read/image/_metadata.py
@@ -1,4 +1,5 @@
 from abc import ABC, abstractmethod
+from typing import Any
 
 from pydantic import BaseModel
 
@@ -40,3 +41,7 @@ class ImageMetadata(BaseModel, ABC):
     @abstractmethod
     def from_file(path: str):
         raise NotImplementedError
+
+
+class CZIImageMetadata(ImageMetadata):
+    metadata: dict[str, Any]

--- a/src/dvpio/read/image/_metadata.py
+++ b/src/dvpio/read/image/_metadata.py
@@ -51,6 +51,63 @@ class CZIImageMetadata(ImageMetadata):
     def image_type(self) -> str:
         return "czi"
 
+    def parse_channel_id(self, channel_name: str) -> int:
+        """Parse CZI channel id representation to channel index"""
+        if channel_name is None:
+            return
+        return int(channel_name.replace("Channel:", ""))
+
+    @computed_field
+    @property
+    def channel_info(self) -> list[dict[str, str]]:
+        """Obtain channel metadata from CZI metadata file
+
+        Notes
+        -----
+        CZI represents strings in the `Channel` metadata field as list of dicts.
+        The dict minimally contains an `@ID` and a `PixelType` key, but
+        may also contain a `Name` key.
+        """
+        channels = (
+            self.metadata.get("ImageDocument", {})
+            .get("Metadata", {})
+            .get("Information", {})
+            .get("Image", {})
+            .get("Dimensions", {})
+            .get("Channels", {})
+            .get("Channel")
+        )
+
+        # For a single channel, a dict is returned
+        if isinstance(channels, dict):
+            channels = [channels]
+
+        return channels or []
+
+    @computed_field
+    @property
+    def channel_id(self) -> list[int]:
+        """Parse channel metadata to list of channel ids
+
+        Notes
+        -----
+        Per channel, IDs are stored under the key `@Id` in the form `Channel:<channel id>`
+        in the channel metadata
+        """
+        return [self.parse_channel_id(channel.get("@Id")) for channel in self.channel_info]
+
+    @computed_field
+    @property
+    def channel_names(self) -> list[str]:
+        """Parse channel metadata to list of channel ids
+
+        Notes
+        -----
+        Per channel, names are stored under the key `@Name` as str
+        in the channel metadata
+        """
+        return [channel.get("@Name", str(idx)) for idx, channel in enumerate(self.channel_info)]
+
     @classmethod
     def from_file(cls, path: str) -> BaseModel:
         """Parse metadata from file path

--- a/src/dvpio/read/image/_metadata.py
+++ b/src/dvpio/read/image/_metadata.py
@@ -51,7 +51,7 @@ class CZIImageMetadata(ImageMetadata):
     def image_type(self) -> str:
         return "czi"
 
-    def parse_channel_id(self, channel_name: str) -> int:
+    def _parse_channel_id(self, channel_name: str) -> int:
         """Parse CZI channel id representation to channel index"""
         if channel_name is None:
             return

--- a/src/dvpio/read/image/_metadata.py
+++ b/src/dvpio/read/image/_metadata.py
@@ -69,7 +69,7 @@ class ImageMetadata(BaseModel, ABC):
 class CZIImageMetadata(ImageMetadata):
     metadata: dict[str, Any]
 
-    channel_info_path: ClassVar = (
+    CHANNEL_INFO_PATH: ClassVar = (
         "ImageDocument",
         "Metadata",
         "Information",
@@ -78,9 +78,9 @@ class CZIImageMetadata(ImageMetadata):
         "Channels",
         "Channel",
     )
-    mpp_path: ClassVar = ("ImageDocument", "Metadata", "Scaling", "Items", "Distance")
-    objective_name_path: ClassVar = ("ImageDocument", "Metadata", "Scaling", "AutoScaling", "ObjectiveName")
-    objective_nominal_magnification_path: ClassVar = (
+    MPP_PATH: ClassVar = ("ImageDocument", "Metadata", "Scaling", "Items", "Distance")
+    OBJECTIVE_NAME_PATH: ClassVar = ("ImageDocument", "Metadata", "Scaling", "AutoScaling", "ObjectiveName")
+    OBJECTIVE_NOMINAL_MAGNIFICATION_PATH: ClassVar = (
         "ImageDocument",
         "Metadata",
         "Information",
@@ -122,7 +122,7 @@ class CZIImageMetadata(ImageMetadata):
         The dict minimally contains an `@ID` and a `PixelType` key, but
         may also contain a `Name` key.
         """
-        channels = _get_value_from_nested_dict(self.metadata, self.channel_info_path, default_return_value=[])
+        channels = _get_value_from_nested_dict(self.metadata, self.CHANNEL_INFO_PATH, default_return_value=[])
 
         # For a single channel, a dict is returned
         if isinstance(channels, dict):
@@ -165,7 +165,7 @@ class CZIImageMetadata(ImageMetadata):
         ----
         Pixel resolution is stored in `Distance` field and always specified in meters per pixel
         """
-        return _get_value_from_nested_dict(self.metadata, self.mpp_path, [])
+        return _get_value_from_nested_dict(self.metadata, self.MPP_PATH, [])
 
     @property
     def mpp_x(self) -> float | None:
@@ -192,7 +192,7 @@ class CZIImageMetadata(ImageMetadata):
         this represents the currently utilized objective
         """
         return _get_value_from_nested_dict(
-            nested_dict=self.metadata, keys=self.objective_name_path, default_return_value=None
+            nested_dict=self.metadata, keys=self.OBJECTIVE_NAME_PATH, default_return_value=None
         )
 
     @property
@@ -206,7 +206,7 @@ class CZIImageMetadata(ImageMetadata):
         is given as `NominalMagnification` field.
         """
         objectives = _get_value_from_nested_dict(
-            self.metadata, keys=self.objective_nominal_magnification_path, default_return_value=[]
+            self.metadata, keys=self.OBJECTIVE_NOMINAL_MAGNIFICATION_PATH, default_return_value=[]
         )
 
         if isinstance(objectives, dict):

--- a/src/dvpio/read/image/_metadata.py
+++ b/src/dvpio/read/image/_metadata.py
@@ -94,7 +94,7 @@ class CZIImageMetadata(ImageMetadata):
         Per channel, IDs are stored under the key `@Id` in the form `Channel:<channel id>`
         in the channel metadata
         """
-        return [self.parse_channel_id(channel.get("@Id")) for channel in self._channel_info]
+        return [self._parse_channel_id(channel.get("@Id")) for channel in self._channel_info]
 
     @computed_field
     @property

--- a/src/dvpio/read/image/_metadata.py
+++ b/src/dvpio/read/image/_metadata.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 from typing import Any
 
-from pydantic import BaseModel
+from pydantic import BaseModel, computed_field
 
 
 class ImageMetadata(BaseModel, ABC):
@@ -45,6 +45,11 @@ class ImageMetadata(BaseModel, ABC):
 
 class CZIImageMetadata(ImageMetadata):
     metadata: dict[str, Any]
+
+    @computed_field
+    @property
+    def image_type(self) -> str:
+        return "czi"
 
     @classmethod
     def from_file(cls, path: str) -> BaseModel:

--- a/src/dvpio/read/image/_metadata.py
+++ b/src/dvpio/read/image/_metadata.py
@@ -69,6 +69,7 @@ class ImageMetadata(BaseModel, ABC):
 class CZIImageMetadata(ImageMetadata):
     metadata: dict[str, Any]
 
+    # *_PATH keys in nested dict that lead to the metadata field
     CHANNEL_INFO_PATH: ClassVar = (
         "ImageDocument",
         "Metadata",

--- a/src/dvpio/read/image/_metadata.py
+++ b/src/dvpio/read/image/_metadata.py
@@ -59,7 +59,7 @@ class CZIImageMetadata(ImageMetadata):
 
     @computed_field
     @property
-    def channel_info(self) -> list[dict[str, str]]:
+    def _channel_info(self) -> list[dict[str, str]]:
         """Obtain channel metadata from CZI metadata file
 
         Notes
@@ -94,7 +94,7 @@ class CZIImageMetadata(ImageMetadata):
         Per channel, IDs are stored under the key `@Id` in the form `Channel:<channel id>`
         in the channel metadata
         """
-        return [self.parse_channel_id(channel.get("@Id")) for channel in self.channel_info]
+        return [self.parse_channel_id(channel.get("@Id")) for channel in self._channel_info]
 
     @computed_field
     @property
@@ -106,11 +106,11 @@ class CZIImageMetadata(ImageMetadata):
         Per channel, names are stored under the key `@Name` as str
         in the channel metadata
         """
-        return [channel.get("@Name", str(idx)) for idx, channel in enumerate(self.channel_info)]
+        return [channel.get("@Name", str(idx)) for idx, channel in enumerate(self._channel_info)]
 
     @computed_field
     @property
-    def mpp(self) -> dict[str, dict[str, str]]:
+    def _mpp(self) -> dict[str, dict[str, str]]:
         """Parse pixel resolution from slide image
 
         Note
@@ -135,21 +135,21 @@ class CZIImageMetadata(ImageMetadata):
     @property
     def mpp_x(self) -> float | None:
         """Return resolution in X dimension in [meters per pixel]"""
-        mpp_x = self.mpp.get("X", {}).get("Value", None)
+        mpp_x = self._mpp.get("X", {}).get("Value", None)
         return float(mpp_x) if mpp_x else None
 
     @computed_field
     @property
     def mpp_y(self) -> float | None:
         """Resolution in Y dimension in [meters per pixel]"""
-        mpp_y = self.mpp.get("Y", {}).get("Value", None)
+        mpp_y = self._mpp.get("Y", {}).get("Value", None)
         return float(mpp_y) if mpp_y else None
 
     @computed_field
     @property
     def mpp_z(self) -> float | None:
         """Resolution in Z dimension in [meters per pixel]"""
-        mpp_z = self.mpp.get("Z", {}).get("Value", None)
+        mpp_z = self._mpp.get("Z", {}).get("Value", None)
         return float(mpp_z) if mpp_z else None
 
     @computed_field

--- a/src/dvpio/read/image/_metadata.py
+++ b/src/dvpio/read/image/_metadata.py
@@ -27,43 +27,43 @@ class ImageMetadata(BaseModel, ABC):
         This value does not consider the magnifications by additional optical elements
         in the specific microscopy setup
         """
-        raise NotImplementedError
+        ...
 
     @property
     @abstractmethod
     def mpp_x(self) -> float:
         """Resolution of the image in meters per pixel along x-axis"""
-        raise NotImplementedError
+        ...
 
     @property
     @abstractmethod
     def mpp_y(self) -> float:
         """Resolution of the image in meters per pixel along y-axis"""
-        raise NotImplementedError
+        ...
 
     @property
     @abstractmethod
     def mpp_z(self) -> float:
         """Resolution of the image in meters per pixel along z-axis"""
-        raise NotImplementedError
+        ...
 
     @property
     @abstractmethod
     def channel_names(self) -> list[str] | None:
         """Names of the microscopy channels"""
-        raise NotImplementedError
+        ...
 
     @property
     @abstractmethod
     def image_type(self) -> str:
         """Indicator of the original image format/microscopy vendor"""
-        raise NotImplementedError
+        ...
 
     @classmethod
     @abstractmethod
     def from_file(path: str):
         """Load metadata from microscopy image in path"""
-        raise NotImplementedError
+        ...
 
 
 class CZIImageMetadata(ImageMetadata):

--- a/src/dvpio/read/image/_metadata.py
+++ b/src/dvpio/read/image/_metadata.py
@@ -101,6 +101,11 @@ class CZIImageMetadata(ImageMetadata):
     def channel_names(self) -> list[str]:
         """Parse channel metadata to list of channel ids
 
+        Returns
+        -------
+        List of channel names
+            If no channel name is given, falls back to returning index of channel as string
+
         Notes
         -----
         Per channel, names are stored under the key `@Name` as str

--- a/src/dvpio/read/image/_utils.py
+++ b/src/dvpio/read/image/_utils.py
@@ -14,7 +14,9 @@ def _compute_chunk_sizes_positions(size: int, chunk: int, min_coord: int) -> tup
     lengths = np.full_like(positions, chunk, dtype=int)
 
     # Last position coordinate exceeds maximum coordinate of slide
-    if positions[-1] + chunk > size + min_coord:
+    last_position_coordinate = positions[-1] + chunk
+    slide_max_coordinate = size + min_coord
+    if last_position_coordinate > slide_max_coordinate:
         lengths[-1] = size + min_coord - positions[-1]
 
     return positions, lengths

--- a/src/dvpio/read/image/_utils.py
+++ b/src/dvpio/read/image/_utils.py
@@ -57,8 +57,8 @@ def _compute_chunks(
     # in line with dask.array.block
     tiles = np.array(
         [
-            [[x, y, w, h] for x, w in zip(x_positions, widths, strict=True)]
-            for y, h in zip(y_positions, heights, strict=True)
+            [[x, y, width, height] for x, width in zip(x_positions, widths, strict=True)]
+            for y, height in zip(y_positions, heights, strict=True)
         ],
         dtype=int,
     )

--- a/src/dvpio/read/image/czi.py
+++ b/src/dvpio/read/image/czi.py
@@ -186,22 +186,26 @@ def read_czi(
     pixel_spec, channel_dim = _parse_pixel_type(slide=czidoc_r, channels=channels)
 
     # For multiple indices, validate that all channels are grayscale
+    # Stacking RGB images might lead to unexpected behaviour
     if (len(channels) > 1) and (not all(c == 1 for c in channel_dim)):
         raise ValueError(
             f"""Not all channels in CZI file are one dimensional (dimensionalities: {channel_dim}).
             Currently, only 1D channels are supported for multi-channel images"""
         )
 
-    chunks = _read_chunks(
-        _get_img,
-        slide=czidoc_r,
-        coords=chunk_coords,
-        n_channel=sum(channel_dim),
-        dtype=pixel_spec.dtype,
-        channel=channels,
-        timepoint=timepoint,
-        z_stack=z_stack,
-    )
+    chunks = [
+        _read_chunks(
+            _get_img,
+            slide=czidoc_r,
+            coords=chunk_coords,
+            n_channel=dimensionality,
+            dtype=pixel_spec.dtype,
+            channel=channel,
+            timepoint=timepoint,
+            z_stack=z_stack,
+        )
+        for channel, dimensionality in zip(channels, channel_dim, strict=True)
+    ]
 
     array = _assemble(chunks)
 

--- a/src/dvpio/read/image/czi.py
+++ b/src/dvpio/read/image/czi.py
@@ -182,9 +182,8 @@ def read_czi(
     # Automatically detect channels
     if channels is None:
         channels = czi_metadata.channel_id
-    if isinstance(channels, list):
-        if len(channels) == 1:
-            channels = channels[0]
+    if isinstance(channels, int):
+        channels = [channels]
 
     pixel_spec, channel_dim = _parse_pixel_type(slide=czidoc_r, channels=channels)
 

--- a/src/dvpio/read/image/czi.py
+++ b/src/dvpio/read/image/czi.py
@@ -29,10 +29,10 @@ class CZIPixelType(Enum):
     Bgr96Float = (3, np.float32, ["b", "g", "r"])
     Invalid = (np.nan, np.nan, np.nan)
 
-    def __init__(self, dimensionality: int, dtype: type, c_coords: list[str] | None) -> None:
+    def __init__(self, dimensionality: int, dtype: type, channel_names: list[str] | None) -> None:
         self.dimensionality = dimensionality
         self.dtype = dtype
-        self.c_coords = c_coords
+        self.channel_names = channel_names
 
     def __lt__(self, other: "CZIPixelType") -> bool:
         """Define hierarchy of dtypes according to order of defintion"""
@@ -223,21 +223,20 @@ def read_czi(
 
     array = _assemble(chunks)
 
-    # Determine channel names (c_coords)
-    # Passed c_coords should take precendence
-    # If no c_coords are passed, use pixel_specs.
+    # Passed channel names (c_coords) should take precendence
+    # If no channel names are passed, use pixel_specs.
     # This is useful for BRG images as it automatically sets the channel order correctly
-    if (c_coords := kwargs.pop("c_coords", None)) is None:
-        c_coords = pixel_spec.c_coords
+    if (channel_names := kwargs.pop("c_coords", None)) is None:
+        channel_names = pixel_spec.channel_names
 
     # For grayscale images, extract channel names from metadata
     # Only select channels that were also specified in the function call
-    if c_coords is None:
-        c_coords = np.array(czi_metadata.channel_names)[channels]
+    if channel_names is None:
+        channel_names = np.array(czi_metadata.channel_names)[channels]
 
     return Image2DModel.parse(
         array,
         dims="cyx",
-        c_coords=c_coords,
+        c_coords=channel_names,
         **kwargs,
     )

--- a/src/dvpio/read/image/czi.py
+++ b/src/dvpio/read/image/czi.py
@@ -175,8 +175,9 @@ def read_czi(
     # Define coordinates for chunkwise loading of the slide
     chunk_coords = _compute_chunks(dimensions=(width, height), chunk_size=chunk_size, min_coordinates=(xmin, ymin))
 
-    # Channel processing
-    # Automatically detect channels
+    # We support the option to automatically extract channels from the metadata (None)
+    # Pass a list of indices list[int] or a single index
+    # Here, we assure that the channels variable stores list[int]
     if channels is None:
         channels = czi_metadata.channel_id
     if isinstance(channels, int):

--- a/src/dvpio/read/image/czi.py
+++ b/src/dvpio/read/image/czi.py
@@ -46,7 +46,7 @@ class CZIPixelType(Enum):
         raise ValueError("Element not in defined types")
 
 
-def _parse_pixel_type(slide: pyczi.CziReader, channels: int | list[int]) -> tuple[Any, list[int]]:
+def _parse_pixel_type(slide: pyczi.CziReader, channels: list[int]) -> tuple[Any, list[int]]:
     """Parse CZI channel info and return channel dimensionalities and pixel data types
 
     Parameters
@@ -64,9 +64,6 @@ def _parse_pixel_type(slide: pyczi.CziReader, channels: int | list[int]) -> tupl
         List of dimensions: List of dimensionalities for all channels. Used to infer total dimensionality of resulting dask array
 
     """
-    if isinstance(channels, int):
-        channels = [channels]
-
     pixel_czi_name = [slide.get_channel_pixel_type(c) for c in channels]
     pixel_spec = [CZIPixelType[c] for c in pixel_czi_name]
     complex_pixel_spec = max(pixel_spec)

--- a/src/dvpio/read/image/czi.py
+++ b/src/dvpio/read/image/czi.py
@@ -224,12 +224,10 @@ def read_czi(
     array = _assemble(chunks)
 
     # Determine channel names (c_coords)
-    # Passed c_coords take precendence
-    c_coords = kwargs.pop("c_coords", None)
-
+    # Passed c_coords should take precendence
     # If no c_coords are passed, use pixel_specs.
     # This is useful for BRG images as it automatically sets the channel order correctly
-    if c_coords is None:
+    if (c_coords := kwargs.pop("c_coords", None)) is None:
         c_coords = pixel_spec.c_coords
 
     # For grayscale images, extract channel names from metadata

--- a/src/dvpio/read/image/czi.py
+++ b/src/dvpio/read/image/czi.py
@@ -143,20 +143,21 @@ def read_czi(
 ) -> Image2DModel:
     """Read .czi to Image2DModel
 
-    Uses the CZI API to read .czi Carl Zeiss image format to spatialdata Image format
+    Uses the CZI API to read .czi Carl Zeiss image format to spatialdata image format.
 
     Parameters
     ----------
     path
         Path to file
     chunk_size
-        Size of the individual regions that are read into memory during the process
+        Size of the individual regions that are read into memory during the process.
     channels
-        If multiple channels are available, select these channels
+        Defaults to `None` which automatically selects all available channels. Passing the numeric index of a single or multiple channels
+        subsets the data to the specified channels.
     timepoint
         If timeseries, select the given index (defaults to 0 [first])
     z_stack
-        If z_stack, defaults to the given stack/index (defaults to 0 [first])
+        If z_stack, selects the the given z-plane (defaults to 0 [first])
     kwargs
         Keyword arguments passed to :meth:`spatialdata.models.Image2DModel.parse`
 

--- a/src/dvpio/read/image/czi.py
+++ b/src/dvpio/read/image/czi.py
@@ -185,38 +185,23 @@ def read_czi(
 
     pixel_spec, channel_dim = _parse_pixel_type(slide=czidoc_r, channels=channels)
 
-    if isinstance(channels, list):
-        # Validate that all channels are grayscale
-        if not all(c == 1 for c in channel_dim):
-            raise ValueError(
-                f"""Not all channels in CZI file are one dimensional (dimensionalities: {channel_dim}).
-                Currently, only 1D channels are supported for multi-channel images"""
-            )
-
-        chunks = [
-            _read_chunks(
-                _get_img,
-                slide=czidoc_r,
-                coords=chunk_coords,
-                n_channel=1,
-                dtype=pixel_spec.dtype,
-                channel=c,
-                timepoint=timepoint,
-                z_stack=z_stack,
-            )
-            for c in channels
-        ]
-    else:
-        chunks = _read_chunks(
-            _get_img,
-            slide=czidoc_r,
-            coords=chunk_coords,
-            n_channel=sum(channel_dim),
-            dtype=pixel_spec.dtype,
-            channel=channels,
-            timepoint=timepoint,
-            z_stack=z_stack,
+    # For multiple indices, validate that all channels are grayscale
+    if (len(channels) > 1) and (not all(c == 1 for c in channel_dim)):
+        raise ValueError(
+            f"""Not all channels in CZI file are one dimensional (dimensionalities: {channel_dim}).
+            Currently, only 1D channels are supported for multi-channel images"""
         )
+
+    chunks = _read_chunks(
+        _get_img,
+        slide=czidoc_r,
+        coords=chunk_coords,
+        n_channel=sum(channel_dim),
+        dtype=pixel_spec.dtype,
+        channel=channels,
+        timepoint=timepoint,
+        z_stack=z_stack,
+    )
 
     array = _assemble(chunks)
 

--- a/src/dvpio/read/image/czi.py
+++ b/src/dvpio/read/image/czi.py
@@ -164,23 +164,26 @@ def read_czi(
     -------
     :class:`spatialdata.models.Image2DModel`
     """
+    # Read slide
     czidoc_r = pyczi.CziReader(path)
 
     # Parse metadata
     czi_metadata = CZIImageMetadata(metadata=czidoc_r.metadata)
 
+    # Chunked loading
+    # Read dimensions
+    xmin, ymin, width, height = czidoc_r.total_bounding_rectangle
+
+    # Define coordinates for chunkwise loading of the slide
+    chunk_coords = _compute_chunks(dimensions=(width, height), chunk_size=chunk_size, min_coordinates=(xmin, ymin))
+
+    # Channel processing
     # Automatically detect channels
     if channels is None:
         channels = czi_metadata.channel_id
     if isinstance(channels, list):
         if len(channels) == 1:
             channels = channels[0]
-
-    # Read dimensions
-    xmin, ymin, width, height = czidoc_r.total_bounding_rectangle
-
-    # Define coordinates for chunkwise loading of the slide
-    chunk_coords = _compute_chunks(dimensions=(width, height), chunk_size=chunk_size, min_coordinates=(xmin, ymin))
 
     pixel_spec, channel_dim = _parse_pixel_type(slide=czidoc_r, channels=channels)
 

--- a/tests/read/image/test_czi.py
+++ b/tests/read/image/test_czi.py
@@ -27,7 +27,7 @@ def test_read_czi(dataset: str, xmin: int, ymin: int, width: int, height: int) -
     img_ref = czidoc_r.read(plane={"C": 0, "T": 0, "Z": 0}, roi=(xmin, ymin, width, height))
 
     # Test function
-    array = read_czi(dataset)
+    array = read_czi(dataset, channels=0)
 
     # # Coordinate systems are not aligned, modify roi so that its coordinate system starts at (0, 0)
     x, y = xmin - xmin_czi, ymin - ymin_czi

--- a/tests/read/image/test_metadata.py
+++ b/tests/read/image/test_metadata.py
@@ -1,0 +1,77 @@
+import pytest
+from pydantic import BaseModel
+
+from dvpio.read.image._metadata import CZIImageMetadata
+
+CZI_GROUND_TRUTH = {
+    "./data/zeiss/zeiss/rect-upper-left.czi": {
+        "channel_ids": [0],
+        "channel_names": ["0"],
+        "mpp_x": 0,
+        "mpp_y": 0,
+        "mpp_z": 0,
+        "magnification": None,
+    },
+    "./data/zeiss/zeiss/rect-upper-left.multi-channel.czi": {
+        "channel_ids": [0, 1, 2],
+        "channel_names": ["0", "1", "2"],
+        "mpp_x": 0,
+        "mpp_y": 0,
+        "mpp_z": 0,
+        "magnification": None,
+    },
+    "./data/zeiss/zeiss/rect-upper-left.rgb.czi": {
+        "channel_ids": [0],
+        "channel_names": ["0"],
+        "mpp_x": 0,
+        "mpp_y": 0,
+        "mpp_z": 0,
+        "magnification": None,
+    },
+    "./data/zeiss/zeiss/zeiss_multi-channel.czi": {
+        "channel_ids": [0, 1],
+        "channel_names": ["DAPI", "PGC"],
+        "mpp_x": 4.5502152331985306e-07,
+        "mpp_y": 4.5502152331985306e-07,
+        "mpp_z": None,
+        "magnification": 5,
+    },
+    "./data/zeiss/zeiss/kabatnik2023_20211129_C1.czi": {
+        "channel_ids": [0],
+        "channel_names": ["TL Brightfield"],
+        "mpp_x": 2.1999999999999998e-07,
+        "mpp_y": 2.1999999999999998e-07,
+        "mpp_z": 1.5e-06,
+        "magnification": 20,
+    },
+}
+
+
+@pytest.fixture(params=CZI_GROUND_TRUTH.keys())
+def czi_metadata_parser(request) -> BaseModel:
+    path = request.param
+    return (CZIImageMetadata.from_file(path), CZI_GROUND_TRUTH[path])
+
+
+def test_czi_channel_id_parser(czi_metadata_parser):
+    metadata, ground_truth = czi_metadata_parser
+    assert metadata.channel_id == ground_truth["channel_ids"]
+
+
+def test_czi_channel_names_parser(czi_metadata_parser):
+    metadata, ground_truth = czi_metadata_parser
+    assert metadata.channel_names == ground_truth["channel_names"]
+
+
+def test_czi_mpp_parser(czi_metadata_parser):
+    metadata, ground_truth = czi_metadata_parser
+    assert metadata.mpp_x == ground_truth["mpp_x"]
+    assert metadata.mpp_y == ground_truth["mpp_y"]
+    assert metadata.mpp_z == ground_truth["mpp_z"]
+
+
+def test_czi_magnification_parser(czi_metadata_parser):
+    metadata, ground_truth = czi_metadata_parser
+    assert metadata.magnification == ground_truth["magnification"]
+    assert metadata.mpp_y == ground_truth["mpp_y"]
+    assert metadata.mpp_z == ground_truth["mpp_z"]

--- a/tests/read/image/test_metadata.py
+++ b/tests/read/image/test_metadata.py
@@ -10,7 +10,7 @@ CZI_GROUND_TRUTH = {
         "mpp_x": 0,
         "mpp_y": 0,
         "mpp_z": 0,
-        "magnification": None,
+        "objective_nominal_magnification": None,
     },
     "./data/zeiss/zeiss/rect-upper-left.multi-channel.czi": {
         "channel_ids": [0, 1, 2],
@@ -18,7 +18,7 @@ CZI_GROUND_TRUTH = {
         "mpp_x": 0,
         "mpp_y": 0,
         "mpp_z": 0,
-        "magnification": None,
+        "objective_nominal_magnification": None,
     },
     "./data/zeiss/zeiss/rect-upper-left.rgb.czi": {
         "channel_ids": [0],
@@ -26,7 +26,7 @@ CZI_GROUND_TRUTH = {
         "mpp_x": 0,
         "mpp_y": 0,
         "mpp_z": 0,
-        "magnification": None,
+        "objective_nominal_magnification": None,
     },
     "./data/zeiss/zeiss/zeiss_multi-channel.czi": {
         "channel_ids": [0, 1],
@@ -34,7 +34,7 @@ CZI_GROUND_TRUTH = {
         "mpp_x": 4.5502152331985306e-07,
         "mpp_y": 4.5502152331985306e-07,
         "mpp_z": None,
-        "magnification": 5,
+        "objective_nominal_magnification": 5,
     },
     "./data/zeiss/zeiss/kabatnik2023_20211129_C1.czi": {
         "channel_ids": [0],
@@ -42,7 +42,7 @@ CZI_GROUND_TRUTH = {
         "mpp_x": 2.1999999999999998e-07,
         "mpp_y": 2.1999999999999998e-07,
         "mpp_z": 1.5e-06,
-        "magnification": 20,
+        "objective_nominal_magnification": 20,
     },
 }
 
@@ -77,6 +77,6 @@ def test_czi_mpp_parser(czi_metadata_parser):
 
 def test_czi_magnification_parser(czi_metadata_parser):
     metadata, ground_truth = czi_metadata_parser
-    assert metadata.magnification == ground_truth["magnification"]
+    assert metadata.objective_nominal_magnification == ground_truth["objective_nominal_magnification"]
     assert metadata.mpp_y == ground_truth["mpp_y"]
     assert metadata.mpp_z == ground_truth["mpp_z"]

--- a/tests/read/image/test_metadata.py
+++ b/tests/read/image/test_metadata.py
@@ -58,6 +58,11 @@ def test_czi_channel_id_parser(czi_metadata_parser):
     assert metadata.channel_id == ground_truth["channel_ids"]
 
 
+def test_czi_image_type_parser(czi_metadata_parser):
+    metadata, ground_truth = czi_metadata_parser
+    assert metadata.image_type == "czi"
+
+
 def test_czi_channel_names_parser(czi_metadata_parser):
     metadata, ground_truth = czi_metadata_parser
     assert metadata.channel_names == ground_truth["channel_names"]


### PR DESCRIPTION
This PR addresses issue #46. It automatically extracts the channel names from a `.czi` microscopy file and parses them with `pydantic`. Additionally, it extracts other useful metadata such as pixel resolution and magnification. 

## Implementation 
The metadata parsing is implemented as `pydantic` class in the newly created `_metadata.py` file. An abstract base class implements base functions/features and is inherited by the file-specific parsers. 

Currently implemented properties
- File type (here: `czi`) 
- Pixel resolution (meters per pixel/`mpp`) for `x`/`y`/`z` axis (float)
- Magnification of objective (float)
- Channel names (string), either existing channel names or, as a fallback, strings of channel IDs. The channel information is automatically parsed in the `read_czi` function and by default set as the `c_coords` argument.
- Channel IDs (numeric)

The extracted properties are selected based on the available metadata fields in the [`openslide` library](https://openslide.org/api/python/#module-openslide). 

## Missing 
Public function that exposes information other than channel names/channel IDs to the user. At the moment, this cannot be directly passed to `spatialdata.models.Image2DModel` as the unstructured data attribute (`.attrs`) of `spatialdata.models.SpatialElement`s is not written to disk 
- see here: https://github.com/scverse/spatialdata/issues/839#issue-2801872581
- see here: https://github.com/lucas-diedrich/dvp-io/issues/21#issue-2740809356