### PR TITLE
Metadata reader openslide

### DIFF
--- a/src/dvpio/read/image/_metadata.py
+++ b/src/dvpio/read/image/_metadata.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Any, ClassVar, Self
+from typing import Any, ClassVar
 from warnings import warn
 
 import openslide
@@ -232,7 +232,7 @@ class CZIImageMetadata(ImageMetadata):
         return float(objective_nominal_magnification) if objective_nominal_magnification else None
 
     @classmethod
-    def from_file(cls, path: str) -> Self:
+    def from_file(cls, path: str) -> BaseModel:
         with open_czi(path) as czi:
             metadata = czi.metadata
 

--- a/src/dvpio/read/image/_metadata.py
+++ b/src/dvpio/read/image/_metadata.py
@@ -281,7 +281,7 @@ class OpenslideImageMetadata(ImageMetadata):
             "Whole Slide images read by openslide do not contain a MPP property in Z dimension, return None",
             stacklevel=1,
         )
-        return None
+        return
 
     @classmethod
     def from_file(cls, path) -> Self:

--- a/src/dvpio/read/image/_metadata.py
+++ b/src/dvpio/read/image/_metadata.py
@@ -245,7 +245,7 @@ class OpenslideImageMetadata(ImageMetadata):
     # Openslide returns MPP in micrometers per pixel
     # Convert it to meters to pixel for compatibility reasons
     # See https://openslide.org/api/python/#standard-properties
-    LENGTH_TO_METER_CONVERSION: ClassVar[float] = 1e-6
+    MICROMETER_TO_METER_CONVERSION: ClassVar[float] = 1e-6
 
     # Openslide always returns RGBA images. Set channel ids + names as constants
     CHANNEL_IDS: ClassVar[list[int]] = [0, 1, 2, 3]
@@ -276,12 +276,12 @@ class OpenslideImageMetadata(ImageMetadata):
     @property
     def mpp_x(self) -> float | None:
         mpp_x = self.metadata.get(openslide.PROPERTY_NAME_MPP_X)
-        return self.LENGTH_TO_METER_CONVERSION * float(mpp_x) if mpp_x is not None else None
+        return self.MICROMETER_TO_METER_CONVERSION * float(mpp_x) if mpp_x is not None else None
 
     @property
     def mpp_y(self) -> float | None:
         mpp_y = self.metadata.get(openslide.PROPERTY_NAME_MPP_Y)
-        return self.LENGTH_TO_METER_CONVERSION * float(mpp_y) if mpp_y is not None else None
+        return self.MICROMETER_TO_METER_CONVERSION * float(mpp_y) if mpp_y is not None else None
 
     @property
     def mpp_z(self) -> None:

--- a/src/dvpio/read/image/_metadata.py
+++ b/src/dvpio/read/image/_metadata.py
@@ -27,7 +27,7 @@ class ImageMetadata(BaseModel, ABC):
 
         Note
         ----
-        This value does not consider the magnifications by additional optical elements
+        This value does not consider the magnification by additional optical elements
         in the specific microscopy setup
         """
         ...
@@ -249,6 +249,7 @@ class OpenslideImageMetadata(ImageMetadata):
 
     @property
     def image_type(self) -> str:
+        """Indicator of the original image format/microscopy vendor, defaults to openslide if unknown."""
         return self.metadata.get(openslide.PROPERTY_NAME_VENDOR, "openslide")
 
     @property

--- a/src/dvpio/read/image/_metadata.py
+++ b/src/dvpio/read/image/_metadata.py
@@ -254,7 +254,7 @@ class OpenslideImageMetadata(ImageMetadata):
     @property
     def objective_nominal_magnification(self) -> float | None:
         magnification = self.metadata.get(openslide.PROPERTY_NAME_OBJECTIVE_POWER)
-        return self.LENGTH_TO_METER_CONVERSION * float(magnification) if magnification is not None else None
+        return float(magnification) if magnification is not None else None
 
     @property
     def channel_id(self) -> list[int]:

--- a/src/dvpio/read/image/_metadata.py
+++ b/src/dvpio/read/image/_metadata.py
@@ -64,7 +64,7 @@ class ImageMetadata(BaseModel, ABC):
 
     @classmethod
     @abstractmethod
-    def from_file(cls, path: str) -> Self:
+    def from_file(cls, path: str) -> BaseModel:
         """Parse metadata from file path
 
         Parameters
@@ -292,6 +292,6 @@ class OpenslideImageMetadata(ImageMetadata):
         return
 
     @classmethod
-    def from_file(cls, path) -> Self:
+    def from_file(cls, path) -> BaseModel:
         slide = openslide.OpenSlide(path)
         return cls(metadata=slide.properties)

--- a/src/dvpio/read/image/_metadata.py
+++ b/src/dvpio/read/image/_metadata.py
@@ -2,6 +2,7 @@ from abc import ABC, abstractmethod
 from typing import Any, ClassVar
 
 from pydantic import BaseModel
+from pylibCZIrw.czi import open_czi
 
 
 def _get_value_from_nested_dict(nested_dict: dict, keys: list, default_return_value: Any = None) -> Any:
@@ -230,8 +231,6 @@ class CZIImageMetadata(ImageMetadata):
 
     @classmethod
     def from_file(cls, path: str) -> BaseModel:
-        from pylibCZIrw.czi import open_czi
-
         with open_czi(path) as czi:
             metadata = czi.metadata
 

--- a/src/dvpio/read/image/_metadata.py
+++ b/src/dvpio/read/image/_metadata.py
@@ -83,7 +83,7 @@ class CZIImageMetadata(ImageMetadata):
     metadata: dict[str, Any]
 
     # *_PATH keys in nested dict that lead to the metadata field
-    CHANNEL_INFO_PATH: ClassVar = (
+    _CHANNEL_INFO_PATH: ClassVar = (
         "ImageDocument",
         "Metadata",
         "Information",
@@ -92,9 +92,9 @@ class CZIImageMetadata(ImageMetadata):
         "Channels",
         "Channel",
     )
-    MPP_PATH: ClassVar = ("ImageDocument", "Metadata", "Scaling", "Items", "Distance")
-    OBJECTIVE_NAME_PATH: ClassVar = ("ImageDocument", "Metadata", "Scaling", "AutoScaling", "ObjectiveName")
-    OBJECTIVE_NOMINAL_MAGNIFICATION_PATH: ClassVar = (
+    _MPP_PATH: ClassVar = ("ImageDocument", "Metadata", "Scaling", "Items", "Distance")
+    _OBJECTIVE_NAME_PATH: ClassVar = ("ImageDocument", "Metadata", "Scaling", "AutoScaling", "ObjectiveName")
+    _OBJECTIVE_NOMINAL_MAGNIFICATION_PATH: ClassVar = (
         "ImageDocument",
         "Metadata",
         "Information",
@@ -136,7 +136,7 @@ class CZIImageMetadata(ImageMetadata):
         The dict minimally contains an `@ID` and a `PixelType` key, but
         may also contain a `Name` key.
         """
-        channels = _get_value_from_nested_dict(self.metadata, self.CHANNEL_INFO_PATH, default_return_value=[])
+        channels = _get_value_from_nested_dict(self.metadata, self._CHANNEL_INFO_PATH, default_return_value=[])
 
         # For a single channel, a dict is returned
         if isinstance(channels, dict):
@@ -179,7 +179,7 @@ class CZIImageMetadata(ImageMetadata):
         ----
         Pixel resolution is stored in `Distance` field and always specified in meters per pixel
         """
-        return _get_value_from_nested_dict(self.metadata, self.MPP_PATH, [])
+        return _get_value_from_nested_dict(self.metadata, self._MPP_PATH, [])
 
     @property
     def mpp_x(self) -> float | None:
@@ -206,7 +206,7 @@ class CZIImageMetadata(ImageMetadata):
         this represents the currently utilized objective
         """
         return _get_value_from_nested_dict(
-            nested_dict=self.metadata, keys=self.OBJECTIVE_NAME_PATH, default_return_value=None
+            nested_dict=self.metadata, keys=self._OBJECTIVE_NAME_PATH, default_return_value=None
         )
 
     @property
@@ -220,7 +220,7 @@ class CZIImageMetadata(ImageMetadata):
         is given as `NominalMagnification` field.
         """
         objectives = _get_value_from_nested_dict(
-            self.metadata, keys=self.OBJECTIVE_NOMINAL_MAGNIFICATION_PATH, default_return_value=[]
+            self.metadata, keys=self._OBJECTIVE_NOMINAL_MAGNIFICATION_PATH, default_return_value=[]
         )
 
         if isinstance(objectives, dict):
@@ -245,11 +245,11 @@ class OpenslideImageMetadata(ImageMetadata):
     # Openslide returns MPP in micrometers per pixel
     # Convert it to meters to pixel for compatibility reasons
     # See https://openslide.org/api/python/#standard-properties
-    MICROMETER_TO_METER_CONVERSION: ClassVar[float] = 1e-6
+    _MICROMETER_TO_METER_CONVERSION: ClassVar[float] = 1e-6
 
     # Openslide always returns RGBA images. Set channel ids + names as constants
-    CHANNEL_IDS: ClassVar[list[int]] = [0, 1, 2, 3]
-    CHANNEL_NAMES: ClassVar[list[str]] = ["R", "G", "B", "A"]
+    _CHANNEL_IDS: ClassVar[list[int]] = [0, 1, 2, 3]
+    _CHANNEL_NAMES: ClassVar[list[str]] = ["R", "G", "B", "A"]
 
     @property
     def image_type(self) -> str:
@@ -265,23 +265,23 @@ class OpenslideImageMetadata(ImageMetadata):
     def channel_id(self) -> list[int]:
         # Openslide returns RGBA images (4 channels)
         # https://openslide.org/api/python/#openslide.OpenSlide.read_region
-        return self.CHANNEL_IDS
+        return self._CHANNEL_IDS
 
     @property
     def channel_names(self) -> list[int]:
         # Openslide returns RGBA images (channels R, G, B, A)
         # https://openslide.org/api/python/#openslide.OpenSlide.read_region
-        return self.CHANNEL_NAMES
+        return self._CHANNEL_NAMES
 
     @property
     def mpp_x(self) -> float | None:
         mpp_x = self.metadata.get(openslide.PROPERTY_NAME_MPP_X)
-        return self.MICROMETER_TO_METER_CONVERSION * float(mpp_x) if mpp_x is not None else None
+        return self._MICROMETER_TO_METER_CONVERSION * float(mpp_x) if mpp_x is not None else None
 
     @property
     def mpp_y(self) -> float | None:
         mpp_y = self.metadata.get(openslide.PROPERTY_NAME_MPP_Y)
-        return self.MICROMETER_TO_METER_CONVERSION * float(mpp_y) if mpp_y is not None else None
+        return self._MICROMETER_TO_METER_CONVERSION * float(mpp_y) if mpp_y is not None else None
 
     @property
     def mpp_z(self) -> None:

--- a/src/dvpio/read/image/_metadata.py
+++ b/src/dvpio/read/image/_metadata.py
@@ -245,7 +245,11 @@ class OpenslideImageMetadata(ImageMetadata):
     # Openslide returns MPP in micrometers per pixel
     # Convert it to meters to pixel for compatibility reasons
     # See https://openslide.org/api/python/#standard-properties
-    LENGTH_TO_METER_CONVERSION: ClassVar = 1e-6
+    LENGTH_TO_METER_CONVERSION: ClassVar[float] = 1e-6
+
+    # Openslide always returns RGBA images. Set channel ids + names as constants
+    CHANNEL_IDS: ClassVar[list[int]] = [0, 1, 2, 3]
+    CHANNEL_NAMES: ClassVar[list[str]] = ["R", "G", "B", "A"]
 
     @property
     def image_type(self) -> str:
@@ -261,13 +265,13 @@ class OpenslideImageMetadata(ImageMetadata):
     def channel_id(self) -> list[int]:
         # Openslide returns RGBA images (4 channels)
         # https://openslide.org/api/python/#openslide.OpenSlide.read_region
-        return list(range(4))
+        return self.CHANNEL_IDS
 
     @property
     def channel_names(self) -> list[int]:
         # Openslide returns RGBA images (channels R, G, B, A)
         # https://openslide.org/api/python/#openslide.OpenSlide.read_region
-        return ["R", "G", "B", "A"]
+        return self.CHANNEL_NAMES
 
     @property
     def mpp_x(self) -> float | None:

--- a/src/dvpio/read/image/_metadata.py
+++ b/src/dvpio/read/image/_metadata.py
@@ -61,8 +61,18 @@ class ImageMetadata(BaseModel, ABC):
 
     @classmethod
     @abstractmethod
-    def from_file(path: str):
-        """Load metadata from microscopy image in path"""
+    def from_file(cls, path: str):
+        """Parse metadata from file path
+
+        Parameters
+        ----------
+        path
+            Path to microscopy file.
+
+        Returns
+        -------
+        Parsed metadata as pydantic model
+        """
         ...
 
 
@@ -220,17 +230,6 @@ class CZIImageMetadata(ImageMetadata):
 
     @classmethod
     def from_file(cls, path: str) -> BaseModel:
-        """Parse metadata from file path
-
-        Parameters
-        ----------
-        path
-            Path to `.czi` file.
-
-        Returns
-        -------
-        Parsed metadata as pydantic model
-        """
         from pylibCZIrw.czi import open_czi
 
         with open_czi(path) as czi:

--- a/src/dvpio/read/image/_metadata.py
+++ b/src/dvpio/read/image/_metadata.py
@@ -249,11 +249,12 @@ class OpenslideImageMetadata(ImageMetadata):
 
     @property
     def image_type(self) -> str:
-        return self.metadata[openslide.PROPERTY_NAME_VENDOR]
+        return self.metadata.get(openslide.PROPERTY_NAME_VENDOR, "openslide")
 
     @property
     def objective_nominal_magnification(self) -> float | None:
-        return self.LENGTH_TO_METER_CONVERSION * float(self.metadata[openslide.PROPERTY_NAME_OBJECTIVE_POWER])
+        magnification = self.metadata.get(openslide.PROPERTY_NAME_OBJECTIVE_POWER)
+        return self.LENGTH_TO_METER_CONVERSION * float(magnification) if magnification is not None else None
 
     @property
     def channel_id(self) -> list[int]:
@@ -269,11 +270,13 @@ class OpenslideImageMetadata(ImageMetadata):
 
     @property
     def mpp_x(self) -> float | None:
-        return self.LENGTH_TO_METER_CONVERSION * float(self.metadata[openslide.PROPERTY_NAME_MPP_X])
+        mpp_x = self.metadata.get(openslide.PROPERTY_NAME_MPP_X)
+        return self.LENGTH_TO_METER_CONVERSION * float(mpp_x) if mpp_x is not None else None
 
     @property
     def mpp_y(self) -> float | None:
-        return self.LENGTH_TO_METER_CONVERSION * float(self.metadata[openslide.PROPERTY_NAME_MPP_Y])
+        mpp_y = self.metadata.get(openslide.PROPERTY_NAME_MPP_Y)
+        return self.LENGTH_TO_METER_CONVERSION * float(mpp_y) if mpp_y is not None else None
 
     @property
     def mpp_z(self) -> None:

--- a/tests/read/image/test_metadata.py
+++ b/tests/read/image/test_metadata.py
@@ -3,10 +3,11 @@ from typing import Any
 import pytest
 from pydantic import BaseModel
 
-from dvpio.read.image._metadata import CZIImageMetadata, OpenslideImageMetadata, _get_value_from_nested_dict
+from dvpio.read.image._metadata import CZIImageMetadata, _get_value_from_nested_dict
 
 CZI_GROUND_TRUTH = {
     "./data/zeiss/zeiss/rect-upper-left.czi": {
+        "image_type": "czi",
         "channel_ids": [0],
         "channel_names": ["0"],
         "mpp_x": 0,
@@ -15,6 +16,7 @@ CZI_GROUND_TRUTH = {
         "objective_nominal_magnification": None,
     },
     "./data/zeiss/zeiss/rect-upper-left.multi-channel.czi": {
+        "image_type": "czi",
         "channel_ids": [0, 1, 2],
         "channel_names": ["0", "1", "2"],
         "mpp_x": 0,
@@ -23,6 +25,7 @@ CZI_GROUND_TRUTH = {
         "objective_nominal_magnification": None,
     },
     "./data/zeiss/zeiss/rect-upper-left.rgb.czi": {
+        "image_type": "czi",
         "channel_ids": [0],
         "channel_names": ["0"],
         "mpp_x": 0,
@@ -31,6 +34,7 @@ CZI_GROUND_TRUTH = {
         "objective_nominal_magnification": None,
     },
     "./data/zeiss/zeiss/zeiss_multi-channel.czi": {
+        "image_type": "czi",
         "channel_ids": [0, 1],
         "channel_names": ["DAPI", "PGC"],
         "mpp_x": 4.5502152331985306e-07,
@@ -39,6 +43,7 @@ CZI_GROUND_TRUTH = {
         "objective_nominal_magnification": 5,
     },
     "./data/zeiss/zeiss/kabatnik2023_20211129_C1.czi": {
+        "image_type": "czi",
         "channel_ids": [0],
         "channel_names": ["TL Brightfield"],
         "mpp_x": 2.1999999999999998e-07,
@@ -49,7 +54,8 @@ CZI_GROUND_TRUTH = {
 }
 
 OPENSLIDE_GROUND_TRUTH = {
-    "./data/openslide-mirax/Miarx2.2-4-PNG.mrxs": {
+    "./data/openslide-mirax/Mirax2.2-4-PNG.mrxs": {
+        "image_type": "mirax",
         "channel_ids": [0, 1, 2, 3],
         "channel_names": ["R", "G", "B", "A"],
         "mpp_x": 0.23387573964496999 * 1e-6,
@@ -88,12 +94,6 @@ def czi_metadata_parser(request) -> BaseModel:
     return (CZIImageMetadata.from_file(path), CZI_GROUND_TRUTH[path])
 
 
-@pytest.fixture(params=OPENSLIDE_GROUND_TRUTH.keys())
-def openslide_metadata_parser(request) -> BaseModel:
-    path = request.param
-    return (OpenslideImageMetadata.from_file(path), OPENSLIDE_GROUND_TRUTH[path])
-
-
 def test_czi_channel_id_parser(czi_metadata_parser):
     metadata, ground_truth = czi_metadata_parser
     assert metadata.channel_id == ground_truth["channel_ids"]
@@ -101,7 +101,7 @@ def test_czi_channel_id_parser(czi_metadata_parser):
 
 def test_czi_image_type_parser(czi_metadata_parser):
     metadata, ground_truth = czi_metadata_parser
-    assert metadata.image_type == "czi"
+    assert metadata.image_type == ground_truth["image_type"]
 
 
 def test_czi_channel_names_parser(czi_metadata_parser):
@@ -119,5 +119,3 @@ def test_czi_mpp_parser(czi_metadata_parser):
 def test_czi_magnification_parser(czi_metadata_parser):
     metadata, ground_truth = czi_metadata_parser
     assert metadata.objective_nominal_magnification == ground_truth["objective_nominal_magnification"]
-    assert metadata.mpp_y == ground_truth["mpp_y"]
-    assert metadata.mpp_z == ground_truth["mpp_z"]

--- a/tests/read/image/test_metadata.py
+++ b/tests/read/image/test_metadata.py
@@ -3,7 +3,7 @@ from typing import Any
 import pytest
 from pydantic import BaseModel
 
-from dvpio.read.image._metadata import CZIImageMetadata, _get_value_from_nested_dict
+from dvpio.read.image._metadata import CZIImageMetadata, OpenslideImageMetadata, _get_value_from_nested_dict
 
 CZI_GROUND_TRUTH = {
     "./data/zeiss/zeiss/rect-upper-left.czi": {
@@ -48,6 +48,17 @@ CZI_GROUND_TRUTH = {
     },
 }
 
+OPENSLIDE_GROUND_TRUTH = {
+    "./data/openslide-mirax/Miarx2.2-4-PNG.mrxs": {
+        "channel_ids": [0, 1, 2, 3],
+        "channel_names": ["R", "G", "B", "A"],
+        "mpp_x": 0.23387573964496999 * 1e-6,
+        "mpp_y": 0.234330708661417 * 1e-6,
+        "mpp_z": None,
+        "objective_nominal_magnification": 20,
+    }
+}
+
 
 @pytest.fixture(scope="module")
 def nested_dict():
@@ -75,6 +86,12 @@ def test_get_value_from_nested_dict_return_value(
 def czi_metadata_parser(request) -> BaseModel:
     path = request.param
     return (CZIImageMetadata.from_file(path), CZI_GROUND_TRUTH[path])
+
+
+@pytest.fixture(params=OPENSLIDE_GROUND_TRUTH.keys())
+def openslide_metadata_parser(request) -> BaseModel:
+    path = request.param
+    return (OpenslideImageMetadata.from_file(path), OPENSLIDE_GROUND_TRUTH[path])
 
 
 def test_czi_channel_id_parser(czi_metadata_parser):

--- a/tests/read/image/test_metadata.py
+++ b/tests/read/image/test_metadata.py
@@ -3,7 +3,7 @@ from typing import Any
 import pytest
 from pydantic import BaseModel
 
-from dvpio.read.image._metadata import CZIImageMetadata, _get_value_from_nested_dict
+from dvpio.read.image._metadata import CZIImageMetadata, OpenslideImageMetadata, _get_value_from_nested_dict
 
 CZI_GROUND_TRUTH = {
     "./data/zeiss/zeiss/rect-upper-left.czi": {
@@ -118,4 +118,37 @@ def test_czi_mpp_parser(czi_metadata_parser):
 
 def test_czi_magnification_parser(czi_metadata_parser):
     metadata, ground_truth = czi_metadata_parser
+    assert metadata.objective_nominal_magnification == ground_truth["objective_nominal_magnification"]
+
+
+@pytest.fixture(params=OPENSLIDE_GROUND_TRUTH.keys())
+def openslide_metadata_parser(request) -> BaseModel:
+    path = request.param
+    return (OpenslideImageMetadata.from_file(path), OPENSLIDE_GROUND_TRUTH[path])
+
+
+def test_openslide_image_type_parser(openslide_metadata_parser):
+    metadata, ground_truth = openslide_metadata_parser
+    assert metadata.image_type == ground_truth["image_type"]
+
+
+def test_openslide_channel_id_parser(openslide_metadata_parser):
+    metadata, ground_truth = openslide_metadata_parser
+    assert metadata.channel_id == ground_truth["channel_ids"]
+
+
+def test_openslide_channel_names_parser(openslide_metadata_parser):
+    metadata, ground_truth = openslide_metadata_parser
+    assert metadata.channel_names == ground_truth["channel_names"]
+
+
+def test_openslide_mpp_parser(openslide_metadata_parser):
+    metadata, ground_truth = openslide_metadata_parser
+    assert metadata.mpp_x == ground_truth["mpp_x"]
+    assert metadata.mpp_y == ground_truth["mpp_y"]
+    assert metadata.mpp_z == ground_truth["mpp_z"]
+
+
+def test_openslide_magnification_parser(openslide_metadata_parser):
+    metadata, ground_truth = openslide_metadata_parser
     assert metadata.objective_nominal_magnification == ground_truth["objective_nominal_magnification"]


### PR DESCRIPTION
This PR extends the metadata reader for microscopy metadata, initially implemented in #69 #71  to openslide data. The implementation closely follows the previous implementation by inheriting from the abstract base class `ImageMetadata`

## Implementations 
- Openslide metadata parser `OpenslideImageMetadata` class
- Tests 

## Considerations
- The resolution fields have to be converted from micrometers to meters. Use the class variable `LENGTH_TO_METER_CONVERSION` for that. 
- Openslide always returns RGBA images. The returned parameters `channel_names` and `channel_ids` are constants.
- Openslide images do not contain the attribute `mpp_z`, return None instead and print warning.