### PR TITLE
Update installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,11 +47,11 @@ Some critical dependencies of `dvpio` require C++ bindings, so a suitable C++ co
 
 ##### For Unix Users (Linux, macOS)
 
-Ensure `cmake` is installed by running:
+Ensure `cmake` and `libssh2` are installed by running:
 
 ```shell
 # Unix
-conda install -n dvpio conda-forge::cmake
+conda install -n dvpio conda-forge::cmake conda-forge::libssh2
 ```
 
 ##### Windows users

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,6 @@ classifiers = [
 dependencies = [
   "alphabase @ git+https://github.com/MannLabs/alphabase.git@7faa365df569bffd2d10b7ab45efdfa90fcce733",
   "anndata",
-  "napari-spatialdata",
   "openslide-bin",
   "openslide-python",
   "py-lmd",
@@ -42,9 +41,11 @@ optional-dependencies.doc = [
   "ipykernel",
   "ipython",
   "myst-nb>=1.1",
+  "napari-spatialdata",
   "pandas",
   # Until pybtex >0.23.0 releases: https://bitbucket.org/pybtex-devs/pybtex/issues/169/
   "setuptools",
+  "spatialdata-plot",
   "sphinx>=4",
   "sphinx-autodoc-typehints",
   "sphinx-book-theme>=1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,12 +25,13 @@ classifiers = [
 dependencies = [
   "alphabase @ git+https://github.com/MannLabs/alphabase.git@7faa365df569bffd2d10b7ab45efdfa90fcce733",
   "anndata",
+  "numcodecs<0.16",                                                                                     # TODO Remove when this is fixed https://github.com/zarr-developers/zarr-python/issues/2963
   "openslide-bin",
   "openslide-python",
-  "py-lmd",
+  "py-lmd==1.3.2",
+  "pydantic",
   "pylibczirw",
   "spatialdata",
-  "spatialdata-plot",
 ]
 optional-dependencies.dev = [
   "pre-commit",


### PR DESCRIPTION
Fixes #95 

Update installation instructions. Depending on the specific system, libssh2 might not be installed, which is a direct dependency of libCZIrw. Add `libssh2` as additional package to C++-installation instructions.