### PR TITLE
Transformation | Similarity transformation

### DIFF
--- a/src/dvpio/read/shapes/geometry.py
+++ b/src/dvpio/read/shapes/geometry.py
@@ -31,8 +31,6 @@ def compute_affine_transformation(
             precision
         - euclidean (Rigid transform)
             Only translation and rotation are allowed
-    precision
-        Rounding of affine transformation matrix
 
     Returns
     -------
@@ -47,10 +45,7 @@ def compute_affine_transformation(
     if query_points.shape[0] < 3:
         raise ValueError("At least three points are required to compute the transformation.")
 
-    affine_matrix = estimate_transform(ttype=transformation_type, src=query_points, dst=reference_points)
-
-    if precision is not None:
-        affine_matrix = np.around(affine_matrix, precision)
+    affine_matrix = estimate_transform(ttype=transformation_type, src=query_points, dst=reference_points).params
 
     return affine_matrix.T
 

--- a/src/dvpio/read/shapes/geometry.py
+++ b/src/dvpio/read/shapes/geometry.py
@@ -98,10 +98,8 @@ def apply_affine_transformation(
     ----------
     shape
         (N, 2) array of points representing a polygon, with (x, y) as last dimension
-    rotation
-        Rotation matrix (2, 2), representing the rotation between the coordinate systems
-    translation
-        Translation vector (1, 2), representing a translation [=systematic shift] between the coordinate systems
+    affine_transformation
+        Affine transformation applied to shapes
 
     Returns
     -------

--- a/src/dvpio/read/shapes/geometry.py
+++ b/src/dvpio/read/shapes/geometry.py
@@ -33,9 +33,6 @@ def compute_affine_transformation(
     if query_points.shape[0] < 3:
         raise ValueError("At least three points are required to compute the transformation.")
 
-    # query_points = np.concatenate([query_points, np.ones(shape=(query_points.shape[0], 1))], axis=1)
-    # reference_points = np.concatenate([reference_points, np.ones(shape=(reference_points.shape[0], 1))], axis=1)
-    # affine_matrix, _, _, _ = np.linalg.lstsq(query_points, reference_points, rcond=None)
     affine_matrix = estimate_transform(ttype="affine", src=query_points, dst=reference_points)
 
     if precision is not None:

--- a/src/dvpio/read/shapes/geometry.py
+++ b/src/dvpio/read/shapes/geometry.py
@@ -1,6 +1,6 @@
 import numpy as np
 from numpy.typing import NDArray
-from skimage.transform._geometric import _umeyama
+from skimage.transform import estimate_transform
 
 
 def compute_affine_transformation(
@@ -79,7 +79,7 @@ def compute_similarity_transformation(
     if query_points.shape[0] < 3:
         raise ValueError("At least three points are required to compute the transformation.")
 
-    affine_matrix = _umeyama(query_points, reference_points, estimate_scale=True)
+    affine_matrix = estimate_transform(ttype="similarity", src=query_points, dst=reference_points)
 
     if precision is not None:
         affine_matrix = np.around(affine_matrix, precision)

--- a/src/dvpio/read/shapes/geometry.py
+++ b/src/dvpio/read/shapes/geometry.py
@@ -33,9 +33,10 @@ def compute_affine_transformation(
     if query_points.shape[0] < 3:
         raise ValueError("At least three points are required to compute the transformation.")
 
-    query_points = np.concatenate([query_points, np.ones(shape=(query_points.shape[0], 1))], axis=1)
-    reference_points = np.concatenate([reference_points, np.ones(shape=(reference_points.shape[0], 1))], axis=1)
-    affine_matrix, _, _, _ = np.linalg.lstsq(query_points, reference_points, rcond=None)
+    # query_points = np.concatenate([query_points, np.ones(shape=(query_points.shape[0], 1))], axis=1)
+    # reference_points = np.concatenate([reference_points, np.ones(shape=(reference_points.shape[0], 1))], axis=1)
+    # affine_matrix, _, _, _ = np.linalg.lstsq(query_points, reference_points, rcond=None)
+    affine_matrix = estimate_transform(ttype="affine", src=query_points, dst=reference_points)
 
     if precision is not None:
         affine_matrix = np.around(affine_matrix, precision)

--- a/src/dvpio/read/shapes/geometry.py
+++ b/src/dvpio/read/shapes/geometry.py
@@ -38,7 +38,7 @@ def compute_affine_transformation(
     if precision is not None:
         affine_matrix = np.around(affine_matrix, precision)
 
-    return affine_matrix
+    return affine_matrix.T
 
 
 def compute_similarity_transformation(
@@ -82,7 +82,7 @@ def compute_similarity_transformation(
     if precision is not None:
         affine_matrix = np.around(affine_matrix, precision)
 
-    return affine_matrix
+    return affine_matrix.T
 
 
 def apply_affine_transformation(

--- a/src/dvpio/read/shapes/geometry.py
+++ b/src/dvpio/read/shapes/geometry.py
@@ -5,7 +5,7 @@ from numpy.typing import NDArray
 from skimage.transform import estimate_transform
 
 
-def compute_affine_transformation(
+def compute_transformation(
     query_points: NDArray[np.float64],
     reference_points: NDArray[np.float64],
     transformation_type: Literal["similarity", "affine", "euclidean"],
@@ -50,7 +50,7 @@ def compute_affine_transformation(
     return affine_matrix.T
 
 
-def apply_affine_transformation(
+def apply_transformation(
     shape: NDArray[np.float64],
     affine_transformation: NDArray[np.float64],
 ) -> NDArray[np.float64]:

--- a/src/dvpio/read/shapes/geometry.py
+++ b/src/dvpio/read/shapes/geometry.py
@@ -1,10 +1,15 @@
+from typing import Literal
+
 import numpy as np
 from numpy.typing import NDArray
 from skimage.transform import estimate_transform
 
 
 def compute_affine_transformation(
-    query_points: NDArray[np.float64], reference_points: NDArray[np.float64], precision: int | None = None
+    query_points: NDArray[np.float64],
+    reference_points: NDArray[np.float64],
+    transformation_type: Literal["similarity", "affine", "euclidean"],
+    precision: int | None = None,
 ) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
     """Computes the affine transformation mapping query_points to reference_points.
 
@@ -17,6 +22,15 @@ def compute_affine_transformation(
         An (N, 2) array of points in the query coordinate system.
     reference_points
         An (N, 2) array of corresponding points in the reference coordinate system.
+    transformation_type
+        - affine
+            Full affine transformation (scaling, rotation/reflexion, translation, shearing)
+        - similarity
+            Similarity transformation. Compared to an affine transformation, a similarity transformation constraints
+            the solution space to scaling, rotations, reflections, and translations, i.e. angles of shapes are retained.
+            precision
+        - euclidean (Rigid transform)
+            Only translation and rotation are allowed
     precision
         Rounding of affine transformation matrix
 
@@ -33,51 +47,7 @@ def compute_affine_transformation(
     if query_points.shape[0] < 3:
         raise ValueError("At least three points are required to compute the transformation.")
 
-    affine_matrix = estimate_transform(ttype="affine", src=query_points, dst=reference_points)
-
-    if precision is not None:
-        affine_matrix = np.around(affine_matrix, precision)
-
-    return affine_matrix.T
-
-
-def compute_similarity_transformation(
-    query_points: NDArray[np.float64], reference_points: NDArray[np.float64], precision: int | None = None
-):
-    """Compute the similarity transformation that maps query_points to reference_points
-
-    Compared to an affine transformation, a similarity transformation constraints the solution space
-    to scaling, rotations, reflections, and translations, i.e. angles of shapes are retained.
-
-    .. math::
-            Aq = r
-
-    Parameters
-    ----------
-    query_points
-        An (N, 2) array of points in the query coordinate system.
-    reference_points
-        An (N, 2) array of corresponding points in the reference coordinate system.
-    precision
-        Rounding of affine transformation matrix
-
-    Returns
-    -------
-    similarity_transformation
-        Similarity transformation as (3 x 3) matrix
-
-    References
-    ----------
-    Least-squares estimation of transformation parameters between two point patterns, Shinji Umeyama, PAMI 1991, DOI: 10.1109/34.88573
-    """
-    if query_points.shape != reference_points.shape:
-        raise ValueError("Point sets must have the same shape.")
-    if query_points.shape[1] != 2:
-        raise ValueError("Points must be 2D.")
-    if query_points.shape[0] < 3:
-        raise ValueError("At least three points are required to compute the transformation.")
-
-    affine_matrix = estimate_transform(ttype="similarity", src=query_points, dst=reference_points)
+    affine_matrix = estimate_transform(ttype=transformation_type, src=query_points, dst=reference_points)
 
     if precision is not None:
         affine_matrix = np.around(affine_matrix, precision)

--- a/src/dvpio/read/shapes/lmd_reader.py
+++ b/src/dvpio/read/shapes/lmd_reader.py
@@ -72,7 +72,10 @@ def transform_shapes(
     # (Full affine transformation) Compute scaling, rotation+reflection, translation + shearing. In this case, angles are not preserved
     # (Similarity transformation) Constrain the affine transformation to scaling, rotation+reflection, translation. In this case, angles are preserved
     affine_transformation = compute_affine_transformation(
-        calibration_points_source, calibration_points_target, precision=precision
+        calibration_points_source,
+        calibration_points_target,
+        precision=precision,
+        transformation_type=transformation_type,
     )
 
     affine_transformation_inverse = np.around(np.linalg.inv(affine_transformation), precision)

--- a/src/dvpio/read/shapes/lmd_reader.py
+++ b/src/dvpio/read/shapes/lmd_reader.py
@@ -104,7 +104,12 @@ def transform_shapes(
     return transformed_shapes
 
 
-def read_lmd(path: str, calibration_points_image: PointsModel, switch_orientation: bool = False) -> ShapesModel:
+def read_lmd(
+    path: str,
+    calibration_points_image: PointsModel,
+    transformation_type: Literal["similarity", "affine", "euclidean"] = "similarity",
+    switch_orientation: bool = False,
+) -> ShapesModel:
     """Read and parse LMD-formatted masks for the use in spatialdata
 
     Wrapper for pyLMD functions.
@@ -116,6 +121,17 @@ def read_lmd(path: str, calibration_points_image: PointsModel, switch_orientatio
     calibration_points_image
         Calibration points of the image as DataFrame, with 3 calibration points. Point coordinates are
         stored as seperate columns in `x` and `y` column.
+    transformation type:
+        - affine
+            Full affine transformation (scaling, rotation/reflexion, translation, shearing). This operation does not preserve
+            the angles within or distances the shapes
+        - similarity (recommended)
+            Similarity transformation. Compared to an affine transformation, a similarity transformation constraints
+            the solution space to scaling, rotations, reflections, and translations, i.e. angles of shapes are retained.
+            If you only want to map between image and microscopy coordinates only the subset of similarity transformations
+            (scaling, rotation, reflection, translation) is required.
+        - euclidean (Rigid transform)
+            Only translation and rotation are allowed
     switch_orientation
         Per default, LMD is working in a (x, y) coordinate system while the image coordinates are in a (row=y, col=x)
         coordinate system. If True, transform the coordinate systems by mirroring the coordinate system at the
@@ -154,6 +170,7 @@ def read_lmd(path: str, calibration_points_image: PointsModel, switch_orientatio
         shapes=shapes,
         calibration_points_target=calibration_points_image,
         calibration_points_source=calibration_points_lmd,
+        transformation_type=transformation_type,
     )
 
     if switch_orientation:

--- a/src/dvpio/read/shapes/lmd_reader.py
+++ b/src/dvpio/read/shapes/lmd_reader.py
@@ -4,7 +4,7 @@ import shapely
 from spatialdata.models import PointsModel, ShapesModel
 from spatialdata.transformations import Affine, set_transformation
 
-from .geometry import apply_affine_transformation, compute_affine_transformation
+from .geometry import apply_affine_transformation, compute_affine_transformation, compute_similarity_transformation
 
 
 def transform_shapes(
@@ -12,6 +12,8 @@ def transform_shapes(
     calibration_points_target: PointsModel,
     calibration_points_source: PointsModel,
     precision: int = 3,
+    *,
+    full_affine_transformation: bool = False,
 ) -> ShapesModel:
     """Apply coordinate transformation to shapes based on calibration points from a target and a source
 
@@ -29,6 +31,11 @@ def transform_shapes(
         Expects :class:`spatialdata.models.PointsModel` with calibration points in `x`/`y` column
     precision
         Precision of affine transformation
+    full_affine_transformation:
+        Whether to compute the full affine transformation between the point sets. This includes scaling,
+        rotation, reflection, translation, and shearing. This operation does not preserve the angles in the shapes.
+        If you only want to map between image and microscopy coordinates only the subset of similarity transformations
+        (scaling, rotation, reflection, translation) is required.
 
     Returns
     -------
@@ -54,10 +61,16 @@ def transform_shapes(
     calibration_points_source = calibration_points_source[["x", "y"]].to_dask_array().compute()
     calibration_points_target = calibration_points_target[["x", "y"]].to_dask_array().compute()
 
-    # Compute rotation (2x2) and translation (2x1) matrices
-    affine_transformation = compute_affine_transformation(
-        calibration_points_source, calibration_points_target, precision=precision
-    )
+    # (Full affine transformation) Compute scaling, rotation+reflection, translation + shearing. In this case, angles are not preserved
+    # (Similarity transformation) Constrain the affine transformation to scaling, rotation+reflection, translation. In this case, angles are preserved
+    if full_affine_transformation:
+        affine_transformation = compute_affine_transformation(
+            calibration_points_source, calibration_points_target, precision=precision
+        )
+    else:
+        affine_transformation = compute_similarity_transformation(
+            calibration_points_source, calibration_points_target, precision=precision
+        )
 
     affine_transformation_inverse = np.around(np.linalg.inv(affine_transformation), precision)
 

--- a/src/dvpio/read/shapes/lmd_reader.py
+++ b/src/dvpio/read/shapes/lmd_reader.py
@@ -71,12 +71,9 @@ def transform_shapes(
 
     # (Full affine transformation) Compute scaling, rotation+reflection, translation + shearing. In this case, angles are not preserved
     # (Similarity transformation) Constrain the affine transformation to scaling, rotation+reflection, translation. In this case, angles are preserved
-    if transformation_type in ("similarity", "affine", "euclidean"):
-        affine_transformation = compute_affine_transformation(
-            calibration_points_source, calibration_points_target, precision=precision
-        )
-    else:
-        raise ValueError(f"Transformation type must be euclidean/similarity/affine, not {transformation_type}")
+    affine_transformation = compute_affine_transformation(
+        calibration_points_source, calibration_points_target, precision=precision
+    )
 
     affine_transformation_inverse = np.around(np.linalg.inv(affine_transformation), precision)
 

--- a/src/dvpio/read/shapes/lmd_reader.py
+++ b/src/dvpio/read/shapes/lmd_reader.py
@@ -113,7 +113,7 @@ def read_lmd(
     path: str,
     calibration_points_image: PointsModel,
     transformation_type: Literal["similarity", "affine", "euclidean"] = "similarity",
-    precision: int | None = None,
+    precision: int | None = 6,
     switch_orientation: bool = False,
 ) -> ShapesModel:
     """Read and parse LMD-formatted masks for the use in spatialdata
@@ -139,7 +139,8 @@ def read_lmd(
         - euclidean (Rigid transform)
             Only translation and rotation are allowed
     precision
-        Precision of affine transformation.
+        Default 6. Rounding of affine transformation matrix, which can be necessary for numerical stability of shape transformations.
+        Passing `None` skips rounding.
     switch_orientation
         Per default, LMD is working in a (x, y) coordinate system while the image coordinates are in a (row=y, col=x)
         coordinate system. If True, transform the coordinate systems by mirroring the coordinate system at the

--- a/src/dvpio/read/shapes/lmd_reader.py
+++ b/src/dvpio/read/shapes/lmd_reader.py
@@ -6,7 +6,7 @@ import shapely
 from spatialdata.models import PointsModel, ShapesModel
 from spatialdata.transformations import Affine, set_transformation
 
-from .geometry import apply_affine_transformation, compute_affine_transformation
+from .geometry import apply_transformation, compute_transformation
 
 
 def transform_shapes(
@@ -71,7 +71,7 @@ def transform_shapes(
 
     # (Full affine transformation) Compute scaling, rotation+reflection, translation + shearing. In this case, angles are not preserved
     # (Similarity transformation) Constrain the affine transformation to scaling, rotation+reflection, translation. In this case, angles are preserved
-    affine_transformation = compute_affine_transformation(
+    affine_transformation = compute_transformation(
         calibration_points_source,
         calibration_points_target,
         precision=precision,
@@ -89,7 +89,7 @@ def transform_shapes(
     # Iterate through shapes and apply affine transformation
     transformed_shapes = shapes["geometry"].apply(
         lambda shape: shapely.transform(
-            shape, transformation=lambda geom: apply_affine_transformation(geom, affine_transformation)
+            shape, transformation=lambda geom: apply_transformation(geom, affine_transformation)
         )
     )
 

--- a/src/dvpio/write/lmd_writer.py
+++ b/src/dvpio/write/lmd_writer.py
@@ -5,7 +5,7 @@ import numpy as np
 import shapely
 import spatialdata as sd
 
-from dvpio.read.shapes.geometry import apply_affine_transformation
+from dvpio.read.shapes.geometry import apply_transformation
 
 
 def write_lmd(
@@ -95,14 +95,14 @@ def write_lmd(
         ).to_affine_matrix(("x", "y"), ("x", "y"))
 
     # Convert calibration points dataframe to (N, 2) array for pylmd
-    calibration_points_transformed = apply_affine_transformation(
+    calibration_points_transformed = apply_transformation(
         calibration_points[["x", "y"]].to_dask_array().compute(), affine_transformation
     )
 
     annotation_transformed = annotation["geometry"].apply(
         lambda shape: shapely.transform(
             shape,
-            transformation=lambda geom: apply_affine_transformation(geom, affine_transformation),
+            transformation=lambda geom: apply_transformation(geom, affine_transformation),
         )
     )
 

--- a/tests/read/shapes/test_geometry.py
+++ b/tests/read/shapes/test_geometry.py
@@ -57,9 +57,7 @@ def test_compute_affine_transformation(
     affine_transformation: NDArray[np.int64],
     transformation_type: str,
 ) -> None:
-    inferred_transformation = compute_affine_transformation(
-        query, reference, precision=3, transformation_type=transformation_type
-    )
+    inferred_transformation = compute_affine_transformation(query, reference, transformation_type=transformation_type)
     assert np.isclose(inferred_transformation, affine_transformation, rtol=0.001).all()
 
 
@@ -70,7 +68,7 @@ def test_compute_affine_transformation_shear(
     affine_transformation: NDArray[np.int64],
     similarity_transformation: NDArray[np.int64],
 ) -> None:
-    inferred_transformation = compute_affine_transformation(query, reference, transformation_type="affine", precision=3)
+    inferred_transformation = compute_affine_transformation(query, reference, transformation_type="affine")
     assert np.isclose(inferred_transformation, affine_transformation, rtol=0.001).all()
 
 

--- a/tests/read/shapes/test_geometry.py
+++ b/tests/read/shapes/test_geometry.py
@@ -5,7 +5,6 @@ from numpy.typing import NDArray
 from dvpio.read.shapes.geometry import (
     apply_affine_transformation,
     compute_affine_transformation,
-    compute_similarity_transformation,
 )
 
 test_cases = [
@@ -50,23 +49,17 @@ test_cases_shear = [
 ]
 
 
+@pytest.mark.parametrize(["transformation_type"], [("similarity",), ("affine",)])
 @pytest.mark.parametrize(["query", "reference", "affine_transformation"], test_cases)
 def test_compute_affine_transformation(
     query: NDArray[np.float64],
     reference: NDArray[np.int64],
     affine_transformation: NDArray[np.int64],
+    transformation_type: str,
 ) -> None:
-    inferred_transformation = compute_affine_transformation(query, reference, precision=3)
-    assert np.isclose(inferred_transformation, affine_transformation, rtol=0.001).all()
-
-
-@pytest.mark.parametrize(["query", "reference", "affine_transformation"], test_cases)
-def test_compute_similarity_transformation(
-    query: NDArray[np.float64],
-    reference: NDArray[np.int64],
-    affine_transformation: NDArray[np.int64],
-) -> None:
-    inferred_transformation = compute_similarity_transformation(query, reference, precision=3)
+    inferred_transformation = compute_affine_transformation(
+        query, reference, precision=3, transformation_type=transformation_type
+    )
     assert np.isclose(inferred_transformation, affine_transformation, rtol=0.001).all()
 
 
@@ -77,7 +70,7 @@ def test_compute_affine_transformation_shear(
     affine_transformation: NDArray[np.int64],
     similarity_transformation: NDArray[np.int64],
 ) -> None:
-    inferred_transformation = compute_affine_transformation(query, reference, precision=3)
+    inferred_transformation = compute_affine_transformation(query, reference, transformation_type="affine", precision=3)
     assert np.isclose(inferred_transformation, affine_transformation, rtol=0.001).all()
 
 
@@ -88,7 +81,9 @@ def test_compute_similarity_transformation_shear(
     affine_transformation: NDArray[np.int64],
     similarity_transformation: NDArray[np.int64],
 ) -> None:
-    inferred_transformation = compute_similarity_transformation(query, reference, precision=3)
+    inferred_transformation = compute_affine_transformation(
+        query, reference, transformation_type="similarity", precision=3
+    )
     assert np.isclose(inferred_transformation, similarity_transformation, rtol=0.001).all()
 
 

--- a/tests/read/shapes/test_geometry.py
+++ b/tests/read/shapes/test_geometry.py
@@ -3,8 +3,8 @@ import pytest
 from numpy.typing import NDArray
 
 from dvpio.read.shapes.geometry import (
-    apply_affine_transformation,
-    compute_affine_transformation,
+    apply_transformation,
+    compute_transformation,
 )
 
 test_cases = [
@@ -51,24 +51,24 @@ test_cases_shear = [
 
 @pytest.mark.parametrize(["transformation_type"], [("similarity",), ("affine",)])
 @pytest.mark.parametrize(["query", "reference", "affine_transformation"], test_cases)
-def test_compute_affine_transformation(
+def test_compute_transformation(
     query: NDArray[np.float64],
     reference: NDArray[np.int64],
     affine_transformation: NDArray[np.int64],
     transformation_type: str,
 ) -> None:
-    inferred_transformation = compute_affine_transformation(query, reference, transformation_type=transformation_type)
+    inferred_transformation = compute_transformation(query, reference, transformation_type=transformation_type)
     assert np.isclose(inferred_transformation, affine_transformation, rtol=0.001).all()
 
 
 @pytest.mark.parametrize(["query", "reference", "affine_transformation", "similarity_transformation"], test_cases_shear)
-def test_compute_affine_transformation_shear(
+def test_compute_transformation_shear(
     query: NDArray[np.float64],
     reference: NDArray[np.int64],
     affine_transformation: NDArray[np.int64],
     similarity_transformation: NDArray[np.int64],
 ) -> None:
-    inferred_transformation = compute_affine_transformation(query, reference, transformation_type="affine")
+    inferred_transformation = compute_transformation(query, reference, transformation_type="affine")
     assert np.isclose(inferred_transformation, affine_transformation, rtol=0.001).all()
 
 
@@ -79,17 +79,15 @@ def test_compute_similarity_transformation_shear(
     affine_transformation: NDArray[np.int64],
     similarity_transformation: NDArray[np.int64],
 ) -> None:
-    inferred_transformation = compute_affine_transformation(
-        query, reference, transformation_type="similarity", precision=3
-    )
+    inferred_transformation = compute_transformation(query, reference, transformation_type="similarity", precision=3)
     assert np.isclose(inferred_transformation, similarity_transformation, rtol=0.001).all()
 
 
 @pytest.mark.parametrize(["query", "reference", "affine_transformation"], test_cases)
-def test_apply_affine_transformation(
+def test_apply_transformation(
     query: NDArray[np.float64],
     reference: NDArray[np.float64],
     affine_transformation: NDArray[np.float64],
 ) -> None:
-    target = apply_affine_transformation(query, affine_transformation)
+    target = apply_transformation(query, affine_transformation)
     assert np.isclose(target, reference, rtol=0.001).all()

--- a/tests/read/shapes/test_geometry.py
+++ b/tests/read/shapes/test_geometry.py
@@ -5,6 +5,7 @@ from numpy.typing import NDArray
 from dvpio.read.shapes.geometry import (
     apply_affine_transformation,
     compute_affine_transformation,
+    compute_similarity_transformation,
 )
 
 test_cases = [
@@ -35,6 +36,20 @@ test_cases = [
 ]
 
 
+test_cases_shear = [
+    # Add additional shear in which similarity + affine transformation differ
+    (
+        np.array([[0, 0], [1, 0], [0, 1]]),
+        # Point 3 is sheared
+        np.array([[0, 0], [1, 0], [0.5, 1]]),
+        # Affine transformation
+        np.array([[1.0, -0.0, 0.0], [0.5, 1.0, 0.0], [-0.0, 0.0, 1.0]]),
+        # Similarity transformation
+        np.array([[0.875, -0.25, 0.0], [0.25, 0.875, 0.0], [0.125, 0.125, 1.0]]),
+    ),
+]
+
+
 @pytest.mark.parametrize(["query", "reference", "affine_transformation"], test_cases)
 def test_compute_affine_transformation(
     query: NDArray[np.float64],
@@ -43,6 +58,38 @@ def test_compute_affine_transformation(
 ) -> None:
     inferred_transformation = compute_affine_transformation(query, reference, precision=3)
     assert np.isclose(inferred_transformation, affine_transformation, rtol=0.001).all()
+
+
+@pytest.mark.parametrize(["query", "reference", "affine_transformation"], test_cases)
+def test_compute_similarity_transformation(
+    query: NDArray[np.float64],
+    reference: NDArray[np.int64],
+    affine_transformation: NDArray[np.int64],
+) -> None:
+    inferred_transformation = compute_similarity_transformation(query, reference, precision=3)
+    assert np.isclose(inferred_transformation, affine_transformation, rtol=0.001).all()
+
+
+@pytest.mark.parametrize(["query", "reference", "affine_transformation", "similarity_transformation"], test_cases_shear)
+def test_compute_affine_transformation_shear(
+    query: NDArray[np.float64],
+    reference: NDArray[np.int64],
+    affine_transformation: NDArray[np.int64],
+    similarity_transformation: NDArray[np.int64],
+) -> None:
+    inferred_transformation = compute_affine_transformation(query, reference, precision=3)
+    assert np.isclose(inferred_transformation, affine_transformation, rtol=0.001).all()
+
+
+@pytest.mark.parametrize(["query", "reference", "affine_transformation", "similarity_transformation"], test_cases_shear)
+def test_compute_similarity_transformation_shear(
+    query: NDArray[np.float64],
+    reference: NDArray[np.int64],
+    affine_transformation: NDArray[np.int64],
+    similarity_transformation: NDArray[np.int64],
+) -> None:
+    inferred_transformation = compute_similarity_transformation(query, reference, precision=3)
+    assert np.isclose(inferred_transformation, similarity_transformation, rtol=0.001).all()
 
 
 @pytest.mark.parametrize(["query", "reference", "affine_transformation"], test_cases)

--- a/tests/read/shapes/test_lmd_reader.py
+++ b/tests/read/shapes/test_lmd_reader.py
@@ -44,7 +44,7 @@ def test_transform_shapes() -> None:
     ],
 )
 def test_read_lmd(path: str, calibration_points: NDArray[np.float64], ground_truth_path: str) -> None:
-    lmd_shapes = read_lmd(path, calibration_points, switch_orientation=False)
+    lmd_shapes = read_lmd(path, calibration_points, switch_orientation=False, precision=3)
     lmd_centroids = _get_centroid_xy(lmd_shapes["geometry"])
 
     ground_truth = gpd.read_file(ground_truth_path)
@@ -70,7 +70,7 @@ def test_read_lmd(path: str, calibration_points: NDArray[np.float64], ground_tru
     ],
 )
 def test_read_lmd_transformation(path: str, calibration_points: NDArray[np.float64], ground_truth_path: str) -> None:
-    lmd_shapes = read_lmd(path, calibration_points, switch_orientation=False)
+    lmd_shapes = read_lmd(path, calibration_points, switch_orientation=False, precision=3)
 
     assert "to_lmd" in lmd_shapes.attrs.get("transform")
     assert isinstance(lmd_shapes.attrs.get("transform").get("to_lmd"), BaseTransformation)

--- a/tests/write/test_lmd_writer.py
+++ b/tests/write/test_lmd_writer.py
@@ -74,7 +74,7 @@ def test_write_lmd_overwrite(
         annotation_well_column=annotation_well_column,
         overwrite=True,
     )
-    assert True
+    assert os.path.exists(path)
 
     # Write file without overwrite raises error
     with pytest.raises(ValueError):
@@ -97,7 +97,7 @@ def test_read_write_lmd(read_path, calibration_points):
     write_path = os.path.join(mkdtemp(), "test.xml")
 
     # Read in example data
-    gdf = read_lmd(read_path, calibration_points_image=calibration_points)
+    gdf = read_lmd(read_path, calibration_points_image=calibration_points, precision=3)
 
     # Write
     write_lmd(write_path, annotation=gdf, calibration_points=calibration_points)


### PR DESCRIPTION
Breaking change, API change. Computes a similarity transformation instead of an affine transformation as the default transformation when loading shapes from an LMD `.xml` file into a `SpatialElement` 

## Reason 
Translating between image and xml spatial coordinates should, in principle, not require shearing but only rotation+reflexion+scaling operations. To accommodate this, we restrain the transformation space. By adding a new function argument (`transformation_type`), the user is free to select more permissive or rigid transformations.

Thanks @sophiamaedler for making me aware of this. 

## Implementation
Refactors the `geometry.compute_affine_transformation` function so that it now wraps `skimage.transform.estimate_transform` instead of a custom implementation. This allows users to specify the transformation type. 