### PR TITLE
[Bugfix] Fix openslide reader

### DIFF
--- a/src/dvpio/read/image/openslide.py
+++ b/src/dvpio/read/image/openslide.py
@@ -9,7 +9,7 @@ from ._utils import _assemble, _compute_chunks, _read_chunks
 
 
 def _get_img(
-    slide: openslide.ImageSlide,
+    slide: openslide.OpenSlide,
     x0: int,
     y0: int,
     width: int,

--- a/src/dvpio/read/image/openslide.py
+++ b/src/dvpio/read/image/openslide.py
@@ -38,8 +38,9 @@ def _get_img(
     # Shape (x, y, c)
     img = slide.read_region((x0, y0), level=level, size=(width, height))
 
+    # Pillow stores images in (y, x, c) format
     # Return image in (c=4, y, x) format
-    return np.array(img).T
+    return np.array(img).transpose(2, 0, 1)
 
 
 def read_openslide(path: str, chunk_size: tuple[int, int] = (10000, 10000), pyramidal: bool = True) -> Image2DModel:

--- a/tests/read/image/test_openslide.py
+++ b/tests/read/image/test_openslide.py
@@ -3,6 +3,23 @@ import openslide
 import pytest
 
 from dvpio.read.image import read_openslide
+from dvpio.read.image.openslide import _get_img
+
+
+@pytest.mark.parametrize(
+    ("dataset", "xmin", "ymin", "width", "height"),
+    [
+        # Asymmetric
+        ("./data/openslide-mirax/Mirax2.2-4-PNG.mrxs", 0, 0, 500, 1000),
+    ],
+)
+def test_get_image_openslide(dataset, xmin: int, ymin: int, width: int, height: int) -> None:
+    slide = openslide.OpenSlide(dataset)
+    ground_truth_shape = (4, height, width)
+
+    img = _get_img(slide, x0=xmin, y0=ymin, width=width, height=height, level=0)
+
+    assert all(img_dim == ref_dim for img_dim, ref_dim in zip(img.shape, ground_truth_shape, strict=True))
 
 
 # @pytest.mark.skipif(sys.platform != "darwin", reason="Tests fail online due to limited resources")


### PR DESCRIPTION
Previous refactor lead to incorrect parsing of images read with openslide. Openslide returns a Pillow Image with dimension order `(c, x, y)`, while the reader factory expects `(c, y, x)`. This made the assembly step fail.

## Fixes 
- Fix issue: correctly transpose openslide output
- Add test: Add test that would have captured the error. 