### PR TITLE
AnnData factory

### DIFF
--- a/src/dvpio/read/omics/_anndata.py
+++ b/src/dvpio/read/omics/_anndata.py
@@ -1,0 +1,125 @@
+"""Factory class to convert PSM DataFrames to AnnData format.
+
+Copied from alphabase git+https://github.com/MannLabs/alphabase.git@7faa365df569bffd2d10b7ab45efdfa90fcce733
+Author: Magnus Schwörer @mschwoer
+"""
+
+import warnings
+
+import anndata as ad
+import numpy as np
+import pandas as pd
+from alphabase.psm_reader import PSMReaderBase
+from alphabase.psm_reader.keys import PsmDfCols
+
+
+class AnnDataFactory:
+    """Factory class to convert AlphaBase PSM DataFrames to AnnData format."""
+
+    def __init__(self, psm_df: pd.DataFrame):
+        """Initialize AnnDataFactory.
+
+        Parameters
+        ----------
+        psm_df : pd.DataFrame
+            AlphaBase PSM DataFrame containing at minimum the columns:
+            - PsmDfCols.RAW_NAME
+            - PsmDfCols.PROTEINS
+            - PsmDfCols.INTENSITY
+
+        """
+        required_cols = [PsmDfCols.RAW_NAME, PsmDfCols.PROTEINS, PsmDfCols.INTENSITY]
+        missing_cols = [col for col in required_cols if col not in psm_df.columns]
+        if missing_cols:
+            raise ValueError(f"Missing required columns: {missing_cols}")
+
+        self._psm_df = psm_df
+
+        duplicated_proteins = self._psm_df[PsmDfCols.PROTEINS].duplicated()
+        if duplicated_proteins.sum() > 0:
+            warnings.warn(
+                f"Found {duplicated_proteins.sum()} duplicated protein groups. Using only first.", stacklevel=1
+            )
+
+    def create_anndata(self) -> ad.AnnData:
+        """Create AnnData object from PSM DataFrame.
+
+        Returns
+        -------
+        ad.AnnData
+            AnnData object where:
+            - obs (rows) are raw names
+            - var (columns) are proteins
+            - X contains intensity values
+
+        """
+        # Create pivot table: raw names x proteins with intensity values
+        pivot_df = pd.pivot_table(
+            self._psm_df,
+            index=PsmDfCols.RAW_NAME,
+            columns=PsmDfCols.PROTEINS,
+            values=PsmDfCols.INTENSITY,
+            aggfunc="first",
+            fill_value=np.nan,
+            dropna=False,
+        )
+
+        return ad.AnnData(
+            X=pivot_df.values,
+            obs=pd.DataFrame(index=pivot_df.index),
+            var=pd.DataFrame(index=pivot_df.columns),
+        )
+
+    @classmethod
+    def from_files(
+        cls,
+        file_paths: str | list[str],
+        reader_type: str = "maxquant",
+        *,
+        intensity_column: str | None = None,
+        protein_id_column: str | None = None,
+        raw_name_column: str | None = None,
+        **kwargs,
+    ) -> "AnnDataFactory":
+        """Create AnnDataFactory from PSM files.
+
+        Parameters
+        ----------
+        file_paths : Union[str, List[str]]
+            Path(s) to PSM file(s)
+        reader_type : str, optional
+            Type of PSM reader to use, by default "maxquant"
+        intensity_column: str, optional
+            Name of the column storing intensity data. Default is taken from `psm_reader.yaml`
+        protein_id_column: str, optional
+            Name of the column storing proteins ids. Default is taken from `psm_reader.yaml`
+        raw_name_column: str, optional
+            Name of the column storing raw (or run) name. Default is taken from `psm_reader.yaml`
+        **kwargs
+            Additional arguments passed to PSM reader
+
+        Returns
+        -------
+        AnnDataFactory
+            Initialized AnnDataFactory instance
+
+        """
+        from alphabase.psm_reader.psm_reader import psm_reader_provider
+
+        reader: PSMReaderBase = psm_reader_provider.get_reader(reader_type, **kwargs)
+
+        custom_column_mapping = {
+            k: v
+            for k, v in {
+                PsmDfCols.INTENSITY: intensity_column if intensity_column else None,
+                PsmDfCols.PROTEINS: protein_id_column if protein_id_column else None,
+                PsmDfCols.RAW_NAME: raw_name_column if raw_name_column else None,
+            }.items()
+            if v is not None
+        }
+
+        if custom_column_mapping:
+            reader.add_column_mapping(custom_column_mapping)
+
+        psm_df = reader.load(file_paths)
+        return cls(psm_df)

--- a/src/dvpio/read/omics/_anndata.py
+++ b/src/dvpio/read/omics/_anndata.py
@@ -54,6 +54,8 @@ class AnnDataFactory:
 
         """
         # Create pivot table: raw names x proteins with intensity values
+        # Note that precursor reports contain redundant information in case of the protein group intensity
+        # (each precursor gets assigned the same PG intensity). We can therefore pick the first occurence
         pivot_df = pd.pivot_table(
             self._psm_df,
             index=PsmDfCols.RAW_NAME,

--- a/src/dvpio/read/omics/report_reader.py
+++ b/src/dvpio/read/omics/report_reader.py
@@ -3,11 +3,12 @@ from typing import Any
 
 import anndata as ad
 import pandas as pd
-from alphabase._anndata.anndata_factory import AnnDataFactory
 from alphabase.psm_reader.psm_reader import psm_reader_provider
 from spatialdata.models import TableModel
 
 from dvpio._utils import experimental_docs, experimental_log
+
+from ._anndata import AnnDataFactory
 
 
 def available_reader() -> list[str]:
@@ -109,7 +110,7 @@ def read_precursor_table(
     protein_id_column: str | None = None,
     raw_name_column: str | None = None,
     reader_kwargs: Mapping[str, Any] | None = None,
-    **kwargs: Mapping[str, Any],
+    **kwargs: Mapping[str, Any] | None,
 ) -> ad.AnnData:
     """Parse proteomics precursor reports to the :class:`anndata.AnnData` format
 
@@ -178,6 +179,7 @@ def read_precursor_table(
         raise ValueError(f"Argument reader_type must be one of {''.join(available_reader())}, not {reader_type}")
 
     reader_kwargs = {} if reader_kwargs is None else reader_kwargs
+    kwargs = {} if kwargs is None else kwargs
 
     factory = AnnDataFactory.from_files(
         path,

--- a/tests/read/omics/test_report_reader.py
+++ b/tests/read/omics/test_report_reader.py
@@ -204,12 +204,24 @@ def test_parse_df_real_data(
 @pytest.mark.parametrize(
     ("path", "reader_type", "func_kwargs", "shape"),
     [
+        # Read protein groups
         ("./data/omics/alphadia/alphadia.precursors.tsv", "alphadia", {}, (3, 7497)),
         (
             "./data/omics/diann/diann_report.tsv",
             "diann",
             {"intensity_column": "PG.Normalised", "protein_id_column": "Protein.Group", "raw_name_column": "File.Name"},
             (3, 380),
+        ),
+        # Get precursor intensities
+        (
+            "./data/omics/diann/diann_report.tsv",
+            "diann",
+            {
+                "intensity_column": "Precursor.Normalised",
+                "protein_id_column": "Precursor.Id",
+                "raw_name_column": "File.Name",
+            },
+            (3, 1088),
         ),
     ],
 )


### PR DESCRIPTION
This PR makes `dvpio` independent from the `alphabase` development version and will enable a pip-installable release. 

## Changes
Adds copy of the `alphabase.AnnDataFactory` (@mschwoer) to this repository so that the package no longer depends on the development branch of `alphabase`. This redundancy will be removed with the first public release of `alphatools`.

Adds a small test to read precursor-level data with the `alphabase.AnnDataFactory` 