### PR TITLE
Protein Group Reader

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -47,6 +47,7 @@ Automatically extract a controlled vocabulary of image metadata.
     available_reader
     parse_df
     read_precursor_table
+    read_pg_table
 ```
 
 ## Write

--- a/src/dvpio/_utils.py
+++ b/src/dvpio/_utils.py
@@ -59,7 +59,7 @@ def deprecated_log(message=None):
 
             warnings.warn(
                 warning_message,
-                category=UserWarning,
+                category=DeprecationWarning,
                 stacklevel=2,
             )
             return func(*args, **kwargs)

--- a/src/dvpio/_utils.py
+++ b/src/dvpio/_utils.py
@@ -31,3 +31,45 @@ def experimental_log(func):
         return func(*args, **kwargs)
 
     return wrapper
+
+
+def deprecated_docs(func):
+    """Decorator to mark a function as deprecated in the docstring."""
+    func.__doc__ = f"""**Warning: This function is deprecated and will be removed in the next minor release**\n\n
+    {func.__doc__ or ""}"""
+    return func
+
+
+def deprecated_log(message=None):
+    """Decorator to mark a function as deprecated with a warning log.
+
+    Parameters
+    ----------
+    message
+        Optional custom deprecation message. If not provided, uses default format.
+    """
+
+    def decorator(func):
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            if message is None:
+                warning_message = f"Function {func.__name__} is deprecated and will be removed in future versions."
+            else:
+                warning_message = message
+
+            warnings.warn(
+                warning_message,
+                category=UserWarning,
+                stacklevel=2,
+            )
+            return func(*args, **kwargs)
+
+        return wrapper
+
+    # Handle both @deprecated_log and @deprecated_log() usage
+    if callable(message):
+        func = message
+        message = None
+        return decorator(func)
+
+    return decorator

--- a/src/dvpio/read/omics/__init__.py
+++ b/src/dvpio/read/omics/__init__.py
@@ -1,3 +1,3 @@
-from .report_reader import available_reader, parse_df, read_precursor_table
+from .report_reader import available_reader, parse_df, read_pg_table, read_precursor_table
 
-__all__ = ["available_reader", "parse_df", "read_precursor_table"]
+__all__ = ["available_reader", "parse_df", "read_precursor_table", "read_pg_table"]

--- a/src/dvpio/read/omics/report_reader.py
+++ b/src/dvpio/read/omics/report_reader.py
@@ -255,7 +255,6 @@ def read_pg_table(
         Regular expression that identifies correct measurement type. Only relevant if PG matrix contains multiple
         measurement types. For example, alphapept returns the raw protein intensity per sample in column `A` and the
         LFQ corrected value in `A_LFQ`. If `None` uses all columns. Passed to :meth:`alphabase.pg_reader.pg_reader_provider.get_reader`.
-
     reader_provider_kwargs
         Passed to :meth:`alphabase.pg_reader.pg_reader_provider.get_reader`
     kwargs

--- a/src/dvpio/read/omics/report_reader.py
+++ b/src/dvpio/read/omics/report_reader.py
@@ -248,23 +248,14 @@ def read_pg_table(
         Name of engine output, pass the method name of the corresponding reader. You can
         list all available readers with the :func:`dvpio.read.omics.available_reader` helper function
     column_mapping
-        Mapping of additional columns in protein group table to a unified name, defaults to standard colum mapping in alphabase.
-        Passed to :meth:`alphabase.pg_reader.pg_reader_provider.get_reader`.
-        Expected format is
-
-        .. code-block:: python
-
-            {"new_column_name": "column_name_pg_matrix", ...}
-
+        A dictionary of mapping alphabase columns (keys) to the corresponding columns in the other
+        search engine (values). If `None` will be loaded from the `column_mapping` key of the respective
+        search engine in `pg_reader.yaml`. Passed to :meth:`alphabase.pg_reader.pg_reader_provider.get_reader`.
     measurement_regex
-        Regular expression that subsets feature columns to the correct quantification type. Only relevant if PG matrix contains multiple
-        quantification methods per sample. Defaults to raw intensities. Options depend on the reader
+        Regular expression that identifies correct measurement type. Only relevant if PG matrix contains multiple
+        measurement types. For example, alphapept returns the raw protein intensity per sample in column `A` and the
+        LFQ corrected value in `A_LFQ`. If `None` uses all columns. Passed to :meth:`alphabase.pg_reader.pg_reader_provider.get_reader`.
 
-            - None (default): Raw intensities
-            - Reader-specific pre-configured names (e.g. `lfq`): Available intensities in the report (e.g. LFQ)
-            - A valid regular expression
-
-        Use classmethod `get_preconfigured_regex` for the respective reader in `alphabase`
     reader_provider_kwargs
         Passed to :meth:`alphabase.pg_reader.pg_reader_provider.get_reader`
     kwargs

--- a/src/dvpio/read/omics/report_reader.py
+++ b/src/dvpio/read/omics/report_reader.py
@@ -266,7 +266,7 @@ def read_pg_table(
 
         Use classmethod `get_preconfigured_regex` for the respective reader in `alphabase`
     reader_provider_kwargs
-        Passed to :meth:`spatialdata.models.TableModel.parse`
+        Passed to :meth:`alphabase.pg_reader.pg_reader_provider.get_reader`
     kwargs
         Passed to :meth:`spatialdata.models.TableModel.parse`
 

--- a/src/dvpio/read/omics/report_reader.py
+++ b/src/dvpio/read/omics/report_reader.py
@@ -313,6 +313,8 @@ def read_pg_table(
     df = reader.import_file(path)
 
     # Observations x Features
-    adata = ad.AnnData(X=df.values.T, var=df.index.to_frame(), obs=df.columns.to_frame(name=SAMPLE_ID_NAME))
+    adata = ad.AnnData(
+        X=df.values.T, var=df.index.to_frame(index=False), obs=df.columns.to_frame(index=False, name=SAMPLE_ID_NAME)
+    )
 
     return TableModel.parse(adata, **kwargs)

--- a/src/dvpio/read/omics/report_reader.py
+++ b/src/dvpio/read/omics/report_reader.py
@@ -1,5 +1,5 @@
 from collections.abc import Mapping
-from typing import Any
+from typing import Any, Literal
 
 import anndata as ad
 import pandas as pd
@@ -14,9 +14,21 @@ from ._anndata import AnnDataFactory
 SAMPLE_ID_NAME: str = "sample_id"
 
 
-def available_reader() -> list[str]:
-    """Get a list of all available readers, as provided by alphabase"""
-    return sorted(psm_reader_provider.reader_dict.keys())
+def available_reader(reader_type: Literal["psm_reader", "pg_reader"] = "psm_reader") -> list[str]:
+    """Get a list of all available readers, as provided by alphabase
+
+    Parameters
+    ----------
+    reader_type
+        Whether to return readers for peptice spectrum matches (`psm_reader`) or protein group
+        intensities (`pg_reader`)
+    """
+    if reader_type == "psm_reader":
+        return sorted(psm_reader_provider.reader_dict.keys())
+    elif reader_type == "pg_reader":
+        return sorted(pg_reader_provider.reader_dict.keys())
+    else:
+        raise KeyError(f"Pass either `psm_reader` or `pg_reader`, not {reader_type}")
 
 
 def _parse_pandas_index(index: pd.Index | pd.MultiIndex, set_index: str | None = None) -> pd.DataFrame:

--- a/src/dvpio/read/omics/report_reader.py
+++ b/src/dvpio/read/omics/report_reader.py
@@ -252,11 +252,13 @@ def read_pg_table(
         Expected format is
 
         .. code-block:: python
+
             {"new_column_name": "column_name_pg_matrix", ...}
 
     measurement_regex
         Regular expression that subsets feature columns to the correct quantification type. Only relevant if PG matrix contains multiple
         quantification methods per sample. Defaults to raw intensities. Options depend on the reader
+
             - None (default): Raw intensities
             - Reader-specific pre-configured names (e.g. `lfq`): Available intensities in the report (e.g. LFQ)
             - A valid regular expression
@@ -304,7 +306,7 @@ def read_pg_table(
 
     See Also
     --------
-    - `alphabase.pg_reader` module
+    :mod:`alphabase.pg_reader`
     """
     reader = pg_reader_provider.get_reader(
         search_engine, column_mapping=column_mapping, measurement_regex=measurement_regex

--- a/src/dvpio/read/omics/report_reader.py
+++ b/src/dvpio/read/omics/report_reader.py
@@ -219,6 +219,7 @@ def read_pg_table(
     *,
     column_mapping: dict[str, Any] | None = None,
     measurement_regex: str | None = None,
+    reader_provider_kwargs: dict | None = None,
     **kwargs: Any,
 ) -> TableModel:
     """Read protein group table to the :class:`anndata.AnnData` format
@@ -264,7 +265,8 @@ def read_pg_table(
             - A valid regular expression
 
         Use classmethod `get_preconfigured_regex` for the respective reader in `alphabase`
-
+    reader_provider_kwargs
+        Passed to :meth:`spatialdata.models.TableModel.parse`
     kwargs
         Passed to :meth:`spatialdata.models.TableModel.parse`
 
@@ -308,9 +310,15 @@ def read_pg_table(
     --------
     :mod:`alphabase.pg_reader`
     """
-    reader = pg_reader_provider.get_reader(
-        search_engine, column_mapping=column_mapping, measurement_regex=measurement_regex
-    )
+    # Build reader_provider_kwargs
+    # This assures that the default values of the readers are considered (e.g. if `column_mapping="raw"`)
+    reader_provider_kwargs = {} if reader_provider_kwargs is None else reader_provider_kwargs
+    if column_mapping is not None:
+        reader_provider_kwargs["column_mapping"] = column_mapping
+    if measurement_regex is not None:
+        reader_provider_kwargs["measurement_regex"] = measurement_regex
+
+    reader = pg_reader_provider.get_reader(search_engine, **reader_provider_kwargs)
     # Features x Observations
     df = reader.import_file(path)
 

--- a/tests/read/omics/test_report_reader.py
+++ b/tests/read/omics/test_report_reader.py
@@ -239,7 +239,7 @@ def test_read_precursor_table(path: str, reader_type: str, func_kwargs: dict, sh
     ("path", "reader_type", "func_kwargs", "shape", "var_shape"),
     [
         ("./data/omics/alphadia/alphadia.protein-group.tsv", "alphadia", {}, (3, 7497), (7497, 1)),
-        ("./data/omics/alphapept/alphapept.protein-group.csv", "alphapept", {}, (4, 3781), (3781, 5)),
+        ("./data/omics/alphapept/alphapept.protein-group.csv", "alphapept", {}, (2, 3781), (3781, 5)),
     ],
 )
 def test_read_pg_table(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,6 @@
 import pytest
 
-from dvpio._utils import experimental_docs, experimental_log, is_parsed
+from dvpio._utils import deprecated_docs, deprecated_log, experimental_docs, experimental_log, is_parsed
 
 
 @pytest.fixture()
@@ -29,3 +29,82 @@ def test_experimental_log(function_factory):
 
     with pytest.warns(UserWarning, match="is experimental and may change"):
         sample_func()
+
+
+def test_deprecated_docs(function_factory):
+    sample_func = deprecated_docs(function_factory)
+
+    assert "Warning: This function is deprecated" in sample_func.__doc__
+
+
+def test_deprecated_log_default_message(function_factory):
+    """Test deprecated_log with default message using @ syntax."""
+    sample_func = deprecated_log(function_factory)
+
+    with pytest.warns(UserWarning, match="Function sample_func is deprecated and will be removed"):
+        sample_func()
+
+
+def test_deprecated_log_with_parentheses(function_factory):
+    """Test deprecated_log with default message using @deprecated_log() syntax."""
+    sample_func = deprecated_log()(function_factory)
+
+    with pytest.warns(UserWarning, match="Function sample_func is deprecated and will be removed"):
+        sample_func()
+
+
+def test_deprecated_log_custom_message(function_factory):
+    """Test deprecated_log with custom message."""
+    custom_message = "This function is obsolete. Use new_function() instead."
+    sample_func = deprecated_log(custom_message)(function_factory)
+
+    with pytest.warns(UserWarning, match="This function is obsolete. Use new_function\\(\\) instead."):
+        sample_func()
+
+
+def test_deprecated_log_preserves_function_metadata(function_factory):
+    """Test that deprecated_log preserves function name and docstring."""
+    sample_func = deprecated_log(function_factory)
+
+    assert sample_func.__name__ == function_factory.__name__
+    assert sample_func.__doc__ == function_factory.__doc__
+
+
+def test_deprecated_log_preserves_return_value(function_factory):
+    """Test that deprecated_log preserves function return value."""
+
+    def func_with_return():
+        return "test_value"
+
+    decorated_func = deprecated_log(func_with_return)
+
+    with pytest.warns(UserWarning):
+        result = decorated_func()
+
+    assert result == "test_value"
+
+
+def test_deprecated_log_preserves_arguments():
+    """Test that deprecated_log passes through arguments correctly."""
+
+    def func_with_args(a, b, c=None):
+        return (a, b, c)
+
+    decorated_func = deprecated_log(func_with_args)
+
+    with pytest.warns(UserWarning):
+        result = decorated_func(1, 2, c=3)
+
+    assert result == (1, 2, 3)
+
+
+def test_deprecated_log_warning_category():
+    """Test that deprecated_log uses correct warning category."""
+
+    def sample_func():
+        pass
+
+    decorated_func = deprecated_log(sample_func)
+
+    with pytest.warns(UserWarning):
+        decorated_func()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -39,17 +39,11 @@ def test_deprecated_docs(function_factory):
 
 def test_deprecated_log_default_message(function_factory):
     """Test deprecated_log with default message using @ syntax."""
-    sample_func = deprecated_log(function_factory)
-
-    with pytest.warns(UserWarning, match="Function sample_func is deprecated and will be removed"):
-        sample_func()
-
-
-def test_deprecated_log_with_parentheses(function_factory):
-    """Test deprecated_log with default message using @deprecated_log() syntax."""
     sample_func = deprecated_log()(function_factory)
 
-    with pytest.warns(UserWarning, match="Function sample_func is deprecated and will be removed"):
+    with pytest.warns(
+        DeprecationWarning, match="Function sample_func is deprecated and will be removed in future versions"
+    ):
         sample_func()
 
 
@@ -58,7 +52,7 @@ def test_deprecated_log_custom_message(function_factory):
     custom_message = "This function is obsolete. Use new_function() instead."
     sample_func = deprecated_log(custom_message)(function_factory)
 
-    with pytest.warns(UserWarning, match="This function is obsolete. Use new_function\\(\\) instead."):
+    with pytest.warns(DeprecationWarning, match="This function is obsolete. Use new_function\\(\\) instead."):
         sample_func()
 
 
@@ -78,7 +72,7 @@ def test_deprecated_log_preserves_return_value(function_factory):
 
     decorated_func = deprecated_log(func_with_return)
 
-    with pytest.warns(UserWarning):
+    with pytest.warns(DeprecationWarning):
         result = decorated_func()
 
     assert result == "test_value"
@@ -92,7 +86,7 @@ def test_deprecated_log_preserves_arguments():
 
     decorated_func = deprecated_log(func_with_args)
 
-    with pytest.warns(UserWarning):
+    with pytest.warns(DeprecationWarning):
         result = decorated_func(1, 2, c=3)
 
     assert result == (1, 2, 3)
@@ -106,5 +100,5 @@ def test_deprecated_log_warning_category():
 
     decorated_func = deprecated_log(sample_func)
 
-    with pytest.warns(UserWarning):
+    with pytest.warns(DeprecationWarning):
         decorated_func()


### PR DESCRIPTION
Protein group reader functionality, based on `alphabase.pg_reader` module

- Adds wrapper function for protein group tables
- Deprecates `dvpio.read.omics.parse_df` function
- Adds deprecation logic.