### PR TITLE
Update `read_lmd` function

### DIFF
--- a/docs/tutorials/004_scdvp.ipynb
+++ b/docs/tutorials/004_scdvp.ipynb
@@ -229,7 +229,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -238,7 +238,6 @@
     "        lmd_path,\n",
     "        calibration_points_image=sdata.points[\"calibration_points_image\"],\n",
     "        transformation_type=\"similarity\",\n",
-    "        precision=6,\n",
     "    )\n",
     "    .set_index(\"name\", drop=False)\n",
     "    .rename_axis(None, axis=0)\n",
@@ -1407,7 +1406,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "dvpio",
    "language": "python",
    "name": "python3"
   },
@@ -1421,7 +1420,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.11"
+   "version": "3.13.12"
   }
  },
  "nbformat": 4,

--- a/src/dvpio/read/shapes/geometry.py
+++ b/src/dvpio/read/shapes/geometry.py
@@ -9,7 +9,6 @@ def compute_transformation(
     query_points: NDArray[np.float64],
     reference_points: NDArray[np.float64],
     transformation_type: Literal["similarity", "affine", "euclidean"],
-    precision: int | None = None,  # TODO: Remove unused argument
 ) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
     """Computes the affine transformation mapping query_points to reference_points.
 

--- a/src/dvpio/read/shapes/geometry.py
+++ b/src/dvpio/read/shapes/geometry.py
@@ -27,7 +27,6 @@ def compute_transformation(
         - similarity
             Similarity transformation. Compared to an affine transformation, a similarity transformation constraints
             the solution space to scaling, rotations, reflections, and translations, i.e. angles of shapes are retained.
-            precision
         - euclidean (Rigid transform)
             Only translation and rotation are allowed
 

--- a/src/dvpio/read/shapes/geometry.py
+++ b/src/dvpio/read/shapes/geometry.py
@@ -50,6 +50,29 @@ def compute_transformation(
     return affine_matrix
 
 
+def affine_matrix_to_shapely(affine_matrix: np.ndarray) -> np.ndarray:
+    """Transform an affine matrix to the shapely syntax
+
+    Examples
+    --------
+
+    .. code-block:: python
+
+        array = [
+            ['a', 'b', 'x0'],
+            ['c', 'd', 'y0'],
+            [0, 0, 1]
+        ]
+
+        affine_matrix_to_shapely(array)
+        > ['a', 'b', 'c', 'd', 'x0', 'y0']
+    """
+    if affine_matrix.shape != (3, 3):
+        raise ValueError(f"Expected matrix of shape (3, 3), got {affine_matrix.shape}")
+
+    return affine_matrix[[0, 0, 1, 1, 0, 1], [0, 1, 0, 1, 2, 2]]
+
+
 def apply_transformation(
     shape: NDArray[np.float64],
     affine_transformation: NDArray[np.float64],

--- a/src/dvpio/read/shapes/geometry.py
+++ b/src/dvpio/read/shapes/geometry.py
@@ -9,7 +9,7 @@ def compute_transformation(
     query_points: NDArray[np.float64],
     reference_points: NDArray[np.float64],
     transformation_type: Literal["similarity", "affine", "euclidean"],
-    precision: int | None = None,
+    precision: int | None = None,  # TODO: Remove unused argument
 ) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
     """Computes the affine transformation mapping query_points to reference_points.
 

--- a/src/dvpio/read/shapes/geometry.py
+++ b/src/dvpio/read/shapes/geometry.py
@@ -75,5 +75,5 @@ def apply_transformation(
     shape_mod = np.hstack([shape, np.ones(shape=(shape.shape[0], 1))])
     # Apply affine transformation
     shape_transformed = shape_mod @ affine_transformation
-    # Reuturn shape without padded ones
+    # Return shape without padded ones
     return shape_transformed[:, :-1]

--- a/src/dvpio/read/shapes/geometry.py
+++ b/src/dvpio/read/shapes/geometry.py
@@ -56,11 +56,11 @@ def affine_matrix_to_shapely(affine_matrix: np.ndarray) -> np.ndarray:
 
     .. code-block:: python
 
-        array = [
+        array = np.array([
             ['a', 'b', 'x0'],
             ['c', 'd', 'y0'],
-            [0, 0, 1]
-        ]
+            ['0', '0', '1']
+        ])
 
         affine_matrix_to_shapely(array)
         > ['a', 'b', 'c', 'd', 'x0', 'y0']

--- a/src/dvpio/read/shapes/geometry.py
+++ b/src/dvpio/read/shapes/geometry.py
@@ -92,9 +92,8 @@ def apply_transformation(
     NDArray[np.float64]
         Shape (N, 2) after affine transformation.
     """
-    # Extend shape with ones
+    # Pad with ones to create homogeneous coordinates, allowing a single matrix
+    # to represent both linear transformation (scale, rotation, shear) and translation
     shape_mod = np.hstack([shape, np.ones(shape=(shape.shape[0], 1))])
-    # Apply affine transformation
-    shape_transformed = shape_mod @ affine_transformation
-    # Return shape without padded ones
+    shape_transformed = shape_mod @ affine_transformation.T
     return shape_transformed[:, :-1]

--- a/src/dvpio/read/shapes/geometry.py
+++ b/src/dvpio/read/shapes/geometry.py
@@ -47,7 +47,7 @@ def compute_transformation(
 
     affine_matrix = estimate_transform(ttype=transformation_type, src=query_points, dst=reference_points).params
 
-    return affine_matrix.T
+    return affine_matrix
 
 
 def apply_transformation(

--- a/src/dvpio/read/shapes/lmd_reader.py
+++ b/src/dvpio/read/shapes/lmd_reader.py
@@ -99,7 +99,7 @@ def transform_shapes(
     # Set inverse transformation as transformation to leica coordinate system
     set_transformation(
         transformed_shapes,
-        transformation=Affine(affine_transformation_inverse.T, input_axes=("x", "y"), output_axes=("x", "y")),
+        transformation=Affine(affine_transformation_inverse, input_axes=("x", "y"), output_axes=("x", "y")),
         to_coordinate_system="to_lmd",
     )
 

--- a/src/dvpio/read/shapes/lmd_reader.py
+++ b/src/dvpio/read/shapes/lmd_reader.py
@@ -14,7 +14,6 @@ def transform_shapes(
     calibration_points_target: PointsModel,
     calibration_points_source: PointsModel,
     *,
-    precision: int | None = None,
     transformation_type: Literal["similarity", "affine", "euclidean"] = "similarity",
 ) -> ShapesModel:
     """Apply coordinate transformation to shapes based on calibration points from a target and a source
@@ -42,8 +41,6 @@ def transform_shapes(
             (scaling, rotation, reflection, translation) is required.
         - euclidean (Rigid transform)
             Only translation and rotation are allowed
-    precision
-        Rounding digit of affine transformation matrix. Small values (~6) might be necessary for numerical stability of shape transformations.
 
     Returns
     -------
@@ -74,19 +71,13 @@ def transform_shapes(
     affine_transformation = compute_transformation(
         calibration_points_source,
         calibration_points_target,
-        precision=precision,
         transformation_type=transformation_type,
     )
 
     affine_transformation_inverse = np.linalg.inv(affine_transformation)
 
-    # Rounding might be required for numerical stability of shapely transformation
-    if precision is not None:
-        affine_transformation = np.around(affine_transformation, precision)
-        affine_transformation_inverse = np.around(affine_transformation_inverse, precision)
-
-    # Transform shapes
-    # Iterate through shapes and apply affine transformation
+    # Geopandas expects shapely-convention for affine transformation (flat list of parameters)
+    # Use .geometry accessor to make the function independent of naming conventions
     shapely_affine_transformation = affine_matrix_to_shapely(affine_matrix=affine_transformation)
     transformed_shapes = shapes.geometry.affine_transform(shapely_affine_transformation)
 

--- a/src/dvpio/read/shapes/lmd_reader.py
+++ b/src/dvpio/read/shapes/lmd_reader.py
@@ -6,7 +6,7 @@ import shapely
 from spatialdata.models import PointsModel, ShapesModel
 from spatialdata.transformations import Affine, set_transformation
 
-from .geometry import apply_transformation, compute_transformation
+from .geometry import affine_matrix_to_shapely, compute_transformation
 
 
 def transform_shapes(
@@ -87,11 +87,8 @@ def transform_shapes(
 
     # Transform shapes
     # Iterate through shapes and apply affine transformation
-    transformed_shapes = shapes["geometry"].apply(
-        lambda shape: shapely.transform(
-            shape, transformation=lambda geom: apply_transformation(geom, affine_transformation)
-        )
-    )
+    shapely_affine_transformation = affine_matrix_to_shapely(affine_matrix=affine_transformation)
+    transformed_shapes = shapes.geometry.affine_transform(shapely_affine_transformation)
 
     # Reassign as DataFrame and parse with spatialdata
     transformed_shapes = ShapesModel.parse(shapes.assign(geometry=transformed_shapes))

--- a/src/dvpio/read/shapes/lmd_reader.py
+++ b/src/dvpio/read/shapes/lmd_reader.py
@@ -101,7 +101,6 @@ def read_lmd(
     path: str,
     calibration_points_image: PointsModel,
     transformation_type: Literal["similarity", "affine", "euclidean"] = "similarity",
-    precision: int | None = 6,
     switch_orientation: bool = False,
 ) -> ShapesModel:
     """Read and parse LMD-formatted masks for the use in spatialdata
@@ -126,9 +125,6 @@ def read_lmd(
             (scaling, rotation, reflection, translation) is required.
         - euclidean (Rigid transform)
             Only translation and rotation are allowed
-    precision
-        Default 6. Rounding of affine transformation matrix, which can be necessary for numerical stability of shape transformations.
-        Passing `None` skips rounding.
     switch_orientation
         Per default, LMD is working in a (x, y) coordinate system while the image coordinates are in a (row=y, col=x)
         coordinate system. If True, transform the coordinate systems by mirroring the coordinate system at the
@@ -168,7 +164,6 @@ def read_lmd(
         calibration_points_target=calibration_points_image,
         calibration_points_source=calibration_points_lmd,
         transformation_type=transformation_type,
-        precision=precision,
     )
 
     if switch_orientation:

--- a/tests/read/shapes/test_geometry.py
+++ b/tests/read/shapes/test_geometry.py
@@ -4,31 +4,30 @@ from numpy.typing import NDArray
 
 from dvpio.read.shapes.geometry import affine_matrix_to_shapely, apply_transformation, compute_transformation
 
-# TODO: Fix matrices so that transposal is unnecsary
 test_cases = [
     # Scale
     (
         np.array([[0, 0], [1, 0], [0, 1]]),
         np.array([[0, 0], [2, 0], [0, 2]]),
-        np.array([[2, 0, 0], [0, 2, 0], [0, 0, 1]]).T,
+        np.array([[2, 0, 0], [0, 2, 0], [0, 0, 1]]),
     ),
     # Translation
     (
         np.array([[0, 0], [1, 0], [0, 1]]),
         np.array([[1, 1], [2, 1], [1, 2]]),
-        np.array([[1, 0, 0], [0, 1, 0], [1, 1, 1]]).T,
+        np.array([[1, 0, 1], [0, 1, 1], [0, 0, 1]]),
     ),
     # Rotation
     (
         np.array([[0, 0], [1, 0], [0, 1]]),
         np.array([[0, 0], [0, -1], [1, 0]]),
-        np.array([[0, -1, 0], [1, 0, 0], [0, 0, 1]]).T,
+        np.array([[0, 1, 0], [-1, 0, 0], [0, 0, 1]]),
     ),
     # Rotate (-90degrees), scale (x2), translate (1,1)
     (
         np.array([[0, 0], [1, 0], [0, 1]]),
         np.array([[1, 1], [1, 3], [-1, 1]]),
-        np.array([[0, 2, 0], [-2, 0, 0], [1, 1, 1]]).T,
+        np.array([[0, -2, 1], [2, 0, 1], [0, 0, 1]]),
     ),
 ]
 
@@ -40,9 +39,9 @@ test_cases_shear = [
         # Point 3 is sheared
         np.array([[0, 0], [1, 0], [0.5, 1]]),
         # Affine transformation
-        np.array([[1.0, -0.0, 0.0], [0.5, 1.0, 0.0], [-0.0, 0.0, 1.0]]).T,
+        np.array([[1.0, 0.5, -0.0], [-0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]),
         # Similarity transformation
-        np.array([[0.875, -0.25, 0.0], [0.25, 0.875, 0.0], [0.125, 0.125, 1.0]]).T,
+        np.array([[0.875, 0.25, 0.125], [-0.25, 0.875, 0.125], [0.0, 0.0, 1.0]]),
     ),
 ]
 
@@ -87,7 +86,7 @@ def test_apply_transformation(
     reference: NDArray[np.float64],
     affine_transformation: NDArray[np.float64],
 ) -> None:
-    target = apply_transformation(query, affine_transformation.T)  # TODO: Remove transposal
+    target = apply_transformation(query, affine_transformation)
     assert np.isclose(target, reference, rtol=0.001).all()
 
 

--- a/tests/read/shapes/test_geometry.py
+++ b/tests/read/shapes/test_geometry.py
@@ -2,35 +2,33 @@ import numpy as np
 import pytest
 from numpy.typing import NDArray
 
-from dvpio.read.shapes.geometry import (
-    apply_transformation,
-    compute_transformation,
-)
+from dvpio.read.shapes.geometry import affine_matrix_to_shapely, apply_transformation, compute_transformation
 
+# TODO: Fix matrices so that transposal is unnecsary
 test_cases = [
     # Scale
     (
         np.array([[0, 0], [1, 0], [0, 1]]),
         np.array([[0, 0], [2, 0], [0, 2]]),
-        np.array([[2, 0, 0], [0, 2, 0], [0, 0, 1]]),
+        np.array([[2, 0, 0], [0, 2, 0], [0, 0, 1]]).T,
     ),
     # Translation
     (
         np.array([[0, 0], [1, 0], [0, 1]]),
         np.array([[1, 1], [2, 1], [1, 2]]),
-        np.array([[1, 0, 0], [0, 1, 0], [1, 1, 1]]),
+        np.array([[1, 0, 0], [0, 1, 0], [1, 1, 1]]).T,
     ),
     # Rotation
     (
         np.array([[0, 0], [1, 0], [0, 1]]),
         np.array([[0, 0], [0, -1], [1, 0]]),
-        np.array([[0, -1, 0], [1, 0, 0], [0, 0, 1]]),
+        np.array([[0, -1, 0], [1, 0, 0], [0, 0, 1]]).T,
     ),
     # Rotate (-90degrees), scale (x2), translate (1,1)
     (
         np.array([[0, 0], [1, 0], [0, 1]]),
         np.array([[1, 1], [1, 3], [-1, 1]]),
-        np.array([[0, 2, 0], [-2, 0, 0], [1, 1, 1]]),
+        np.array([[0, 2, 0], [-2, 0, 0], [1, 1, 1]]).T,
     ),
 ]
 
@@ -42,9 +40,9 @@ test_cases_shear = [
         # Point 3 is sheared
         np.array([[0, 0], [1, 0], [0.5, 1]]),
         # Affine transformation
-        np.array([[1.0, -0.0, 0.0], [0.5, 1.0, 0.0], [-0.0, 0.0, 1.0]]),
+        np.array([[1.0, -0.0, 0.0], [0.5, 1.0, 0.0], [-0.0, 0.0, 1.0]]).T,
         # Similarity transformation
-        np.array([[0.875, -0.25, 0.0], [0.25, 0.875, 0.0], [0.125, 0.125, 1.0]]),
+        np.array([[0.875, -0.25, 0.0], [0.25, 0.875, 0.0], [0.125, 0.125, 1.0]]).T,
     ),
 ]
 
@@ -89,5 +87,17 @@ def test_apply_transformation(
     reference: NDArray[np.float64],
     affine_transformation: NDArray[np.float64],
 ) -> None:
-    target = apply_transformation(query, affine_transformation)
+    target = apply_transformation(query, affine_transformation.T)  # TODO: Remove transposal
     assert np.isclose(target, reference, rtol=0.001).all()
+
+
+@pytest.mark.parametrize(
+    ("affine_matrix", "expected"),
+    [
+        (np.array([[0, 1, 2], [3, 4, 5], [6, 7, 8]]), np.array([0, 1, 3, 4, 2, 5])),
+    ],
+)
+def test_affine_matrix_to_shapely(affine_matrix: np.ndarray, expected: np.ndarray) -> None:
+    """Test that shapely convention works"""
+    result = affine_matrix_to_shapely(affine_matrix=affine_matrix)
+    assert np.array_equal(result, expected)

--- a/tests/read/shapes/test_geometry.py
+++ b/tests/read/shapes/test_geometry.py
@@ -101,3 +101,11 @@ def test_affine_matrix_to_shapely(affine_matrix: np.ndarray, expected: np.ndarra
     """Test that shapely convention works"""
     result = affine_matrix_to_shapely(affine_matrix=affine_matrix)
     assert np.array_equal(result, expected)
+
+
+@pytest.mark.parametrize("matrix_shape", [(1, 1), (2, 2), (3, 4), (4, 4)], ids=("1x1", "2x2", "3x4", "4x4"))
+def test_affine_matrix_to_shapely__raises_incorrect_shape(matrix_shape: tuple[int, int]) -> None:
+    """Test that function raises if shape is incorrect"""
+    affine_matrix = np.zeros(shape=matrix_shape)
+    with pytest.raises(ValueError, match="Expected matrix of shape"):
+        _ = affine_matrix_to_shapely(affine_matrix=affine_matrix)

--- a/tests/read/shapes/test_geometry.py
+++ b/tests/read/shapes/test_geometry.py
@@ -77,7 +77,7 @@ def test_compute_similarity_transformation_shear(
     affine_transformation: NDArray[np.int64],
     similarity_transformation: NDArray[np.int64],
 ) -> None:
-    inferred_transformation = compute_transformation(query, reference, transformation_type="similarity", precision=3)
+    inferred_transformation = compute_transformation(query, reference, transformation_type="similarity")
     assert np.isclose(inferred_transformation, similarity_transformation, rtol=0.001).all()
 
 

--- a/tests/read/shapes/test_lmd_reader.py
+++ b/tests/read/shapes/test_lmd_reader.py
@@ -44,7 +44,7 @@ def test_transform_shapes() -> None:
     ],
 )
 def test_read_lmd(path: str, calibration_points: NDArray[np.float64], ground_truth_path: str) -> None:
-    lmd_shapes = read_lmd(path, calibration_points, switch_orientation=False, precision=3)
+    lmd_shapes = read_lmd(path, calibration_points, switch_orientation=False)
     lmd_centroids = _get_centroid_xy(lmd_shapes["geometry"])
 
     ground_truth = gpd.read_file(ground_truth_path)
@@ -70,7 +70,7 @@ def test_read_lmd(path: str, calibration_points: NDArray[np.float64], ground_tru
     ],
 )
 def test_read_lmd_transformation(path: str, calibration_points: NDArray[np.float64], ground_truth_path: str) -> None:
-    lmd_shapes = read_lmd(path, calibration_points, switch_orientation=False, precision=3)
+    lmd_shapes = read_lmd(path, calibration_points, switch_orientation=False)
 
     assert "to_lmd" in lmd_shapes.attrs.get("transform")
     assert isinstance(lmd_shapes.attrs.get("transform").get("to_lmd"), BaseTransformation)

--- a/tests/write/test_lmd_writer.py
+++ b/tests/write/test_lmd_writer.py
@@ -13,7 +13,7 @@ from dvpio.write import write_lmd
 @pytest.fixture
 def dummy_data() -> tuple[ShapesModel, PointsModel]:
     """Example data - calibration points and triangular shapes"""
-    calibration_points_image = PointsModel.parse(np.array([[0, 2], [2, 2], [2, 0]]))
+    calibration_points_image = PointsModel.parse(np.array([[0, 200], [200, 200], [200, 0]]))
     gdf = read_lmd("./data/triangles/collection.xml", calibration_points_image=calibration_points_image)
 
     return gdf, calibration_points_image
@@ -157,11 +157,11 @@ def test_read_write_lmd(tmp_path, dummy_data, read_path):
     write_lmd(write_path, annotation=gdf, calibration_points=calibration_points)
 
     # Compare original (ref) with rewritten copy
-    ref = pylmd.Collection()
+    ref = pylmd.Collection(scale=1, orientation_transform=np.eye(2))
     ref.load(read_path)
     ref = ref.to_geopandas()
 
-    query = pylmd.Collection()
+    query = pylmd.Collection(scale=1, orientation_transform=np.eye(2))
     query.load(write_path)
     query = query.to_geopandas()
 

--- a/tests/write/test_lmd_writer.py
+++ b/tests/write/test_lmd_writer.py
@@ -151,7 +151,7 @@ def test_read_write_lmd(tmp_path, dummy_data, read_path):
     _, calibration_points = dummy_data
 
     # Read in example data
-    gdf = read_lmd(read_path, calibration_points_image=calibration_points, precision=3)
+    gdf = read_lmd(read_path, calibration_points_image=calibration_points)
 
     # Write
     write_lmd(write_path, annotation=gdf, calibration_points=calibration_points)


### PR DESCRIPTION
Use `geopandas` built-in affine-transform for transformation handling in `read_lmd`. This increases robustness as `geopandas` can handle different geometries better enables us to get rid of the unintuitive `precision` parameter.

Additionally fixed the fact that the affine transformation matrices were transposed compared to the standard convention. 

Breaking change as the `precision` parameter got removed. To mitigate: Remove `precision` argument from function calls of `read_lmd`.

