### PR TITLE
Tiff Writer

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ classifiers = [
 dependencies = [
   "alphabase",
   "anndata",
+  "ome-types",
   "openslide-bin",
   "openslide-python",
   "pandas<3",         # TODO: Remove dependeny bound as soon as pandas 3.0 API is stable

--- a/src/dvpio/write/image/__init__.py
+++ b/src/dvpio/write/image/__init__.py
@@ -1,1 +1,3 @@
 from .tiff_writer import write_ome_tiff
+
+__all__ = ["write_ome_tiff"]

--- a/src/dvpio/write/image/__init__.py
+++ b/src/dvpio/write/image/__init__.py
@@ -1,0 +1,1 @@
+from .tiff_writer import write_ome_tiff

--- a/src/dvpio/write/image/tiff_writer.py
+++ b/src/dvpio/write/image/tiff_writer.py
@@ -1,0 +1,123 @@
+"""Convert a spatialdatat image to ome-tiff"""
+
+import warnings
+from collections.abc import Generator
+
+import dask.array as da
+import numpy as np
+import spatialdata as sd
+import tifffile
+import xarray as xr
+
+
+def get_raster(raster: sd.models.Image2DModel | sd.models.Labels2DModel, level: str = "scale0") -> xr.DataArray:
+    """Get raster layer of spatialdata object as :class:`xr.DataArray`
+
+    Parameters
+    ----------
+    image
+        Either :class:`spatialdata.models.Image2DModel` or :class:`spatialdata.models.Label2DModel`
+    level
+        Level in multiscale image to use. Defaults to None which returns the highest level.
+
+    Returns
+    -------
+    :class:`xr.DataArray`
+        DataArray
+    """
+    if isinstance(raster, xr.DataArray):
+        if level is not None:
+            warnings.warn("Argument level is not None and will be ignored for `xr.DataArray`", stacklevel=2)
+        return raster
+
+    elif isinstance(raster, xr.DataTree):
+        data_at_level = raster.get(key=level)
+
+        if data_at_level is None:
+            raise KeyError(f"Level '{level}' not found in layer with levels {list(raster.children.keys())}")
+
+        return (
+            data_at_level.to_dataset()
+            # xarray introduces a new dimension in which data variable are broadcasted against each other
+            # This dimension is empty for spatialdata.Image2DModels.
+            .to_array(dim="variable")
+            .drop_vars("variable", errors="raise")
+            .squeeze()
+        )
+    else:
+        raise ValueError(f"Unknown raster type, {type(raster)}")
+
+
+def _iter_tiles(array: da.Array, tile_shape=(512, 512)) -> Generator[np.ndarray, None, None]:
+    """Yield (y, x) tiles from a dask array for memory-efficient TIFF writing.
+
+    Iterates over all leading dimensions (C, Z, T, ...) and yields tiles
+    in the order expected by tifffile, computing only one tile at a time.
+    """
+    shape = array.shape
+    height, width = shape[-2], shape[-1]
+    tile_y, tile_x = tile_shape
+
+    leading_shape = shape[:-2] if len(shape) > 2 else ()
+    indices = np.ndindex(*leading_shape) if leading_shape else [()]
+
+    for idx in indices:
+        plane = array[idx] if leading_shape else array
+        for y in range(0, height, tile_y):
+            for x in range(0, width, tile_x):
+                tile = plane[y : y + tile_y, x : x + tile_x]
+                if isinstance(tile, da.Array):
+                    tile = tile.compute()
+                yield tile
+
+
+def write_ome_tiff(
+    path: str, image: sd.models.Image2DModel, tile_shape: tuple[int, int] = (1024, 1024), level: str | None = None
+) -> None:
+    """Export image data to ome-tiff
+
+    Enables out-of-memory computation by writing the data iteratively to disk.
+
+    Parameters
+    ----------
+    image
+        Spatialdata Image2DModel. Only writes top-level for pyramidal images.
+    path : Path
+        Output path for the ome-tiff file.
+    tile_shape
+        (height, width) of each tile written to the TIFF image. Tile shape must be a multiple of 16.
+    level
+        Level in mulitscale image to write. If `None`, defaults to highest level. Is ignored for
+        single-scale images.
+
+    Returns
+    -------
+    Writes an `OME-TIFF` image of the form ... to disk
+
+    Example
+    -------
+
+    .. code-block:: python
+
+        # Write an image with default parameters
+        write_ome_tiff(path, sdata["image"])
+
+        # Write a multiscale image at a lower resolution level
+        write_ome_tiff(path, sdata["image"], level="scale2")
+
+    """
+    sd.models.Image2DModel.validate(image)
+
+    image = get_raster(image, level=level)
+
+    with tifffile.TiffWriter(path, bigtiff=True) as tw:
+        tw.write(
+            _iter_tiles(image.data, tile_shape),
+            shape=image.data.shape,
+            dtype=image.data.dtype,
+            tile=tile_shape,
+            photometric="minisblack",
+            subifds=None,
+            description=None,
+            metadata=None,
+        )

--- a/src/dvpio/write/image/tiff_writer.py
+++ b/src/dvpio/write/image/tiff_writer.py
@@ -114,7 +114,7 @@ def write_ome_tiff(
         write_ome_tiff(path, sdata["multiscale_image"], level="scale2")
 
     """
-    sd.models.Image2DModel.validate(image)
+    sd.models.Image2DModel().validate(image)
 
     image = get_raster(image, level=level)
     metadata = OME(**metadata).to_xml() if metadata is not None else None

--- a/src/dvpio/write/image/tiff_writer.py
+++ b/src/dvpio/write/image/tiff_writer.py
@@ -2,6 +2,7 @@
 
 import warnings
 from collections.abc import Generator
+from pathlib import Path
 from typing import Any
 
 import dask.array as da
@@ -77,7 +78,7 @@ def _iter_tiles(array: np.ndarray | da.Array, tile_shape=(512, 512)) -> Generato
 
 
 def write_ome_tiff(
-    path: str,
+    path: Path,
     image: sd.models.Image2DModel,
     metadata: dict[str, Any] | None = None,
     tile_shape: tuple[int, int] = (1024, 1024),

--- a/src/dvpio/write/image/tiff_writer.py
+++ b/src/dvpio/write/image/tiff_writer.py
@@ -2,12 +2,14 @@
 
 import warnings
 from collections.abc import Generator
+from typing import Any
 
 import dask.array as da
 import numpy as np
 import spatialdata as sd
 import tifffile
 import xarray as xr
+from ome_types import OME
 
 
 def get_raster(raster: sd.models.Image2DModel | sd.models.Labels2DModel, level: str = "scale0") -> xr.DataArray:
@@ -72,7 +74,11 @@ def _iter_tiles(array: da.Array, tile_shape=(512, 512)) -> Generator[np.ndarray,
 
 
 def write_ome_tiff(
-    path: str, image: sd.models.Image2DModel, tile_shape: tuple[int, int] = (1024, 1024), level: str | None = None
+    path: str,
+    image: sd.models.Image2DModel,
+    metadata: dict[str, Any] | None = None,
+    tile_shape: tuple[int, int] = (1024, 1024),
+    level: str | None = None,
 ) -> None:
     """Export image data to ome-tiff
 
@@ -80,10 +86,12 @@ def write_ome_tiff(
 
     Parameters
     ----------
+    path
+        Output path for the ome-tiff file.
     image
         Spatialdata Image2DModel. Only writes top-level for pyramidal images.
-    path : Path
-        Output path for the ome-tiff file.
+    metadata
+        Metadata dictionary compatible with the `OME` schema.
     tile_shape
         (height, width) of each tile written to the TIFF image. Tile shape must be a multiple of 16.
     level
@@ -109,6 +117,7 @@ def write_ome_tiff(
     sd.models.Image2DModel.validate(image)
 
     image = get_raster(image, level=level)
+    metadata = OME(**metadata).to_xml() if metadata is not None else None
 
     with tifffile.TiffWriter(path, bigtiff=True) as tw:
         tw.write(
@@ -118,6 +127,5 @@ def write_ome_tiff(
             tile=tile_shape,
             photometric="minisblack",
             subifds=None,
-            description=None,
             metadata=None,
         )

--- a/src/dvpio/write/image/tiff_writer.py
+++ b/src/dvpio/write/image/tiff_writer.py
@@ -12,7 +12,7 @@ import xarray as xr
 from ome_types import OME
 
 
-def get_raster(raster: sd.models.Image2DModel | sd.models.Labels2DModel, level: str = "scale0") -> xr.DataArray:
+def get_raster(raster: sd.models.Image2DModel | sd.models.Labels2DModel, level: str | None = None) -> xr.DataArray:
     """Get raster layer of spatialdata object as :class:`xr.DataArray`
 
     Parameters
@@ -33,7 +33,8 @@ def get_raster(raster: sd.models.Image2DModel | sd.models.Labels2DModel, level: 
         return raster
 
     elif isinstance(raster, xr.DataTree):
-        data_at_level = raster.get(key=level)
+        # Get first descendant (highest resolution) per default
+        data_at_level = raster.get(key=level) if level is not None else raster.descendants[0]
 
         if data_at_level is None:
             raise KeyError(f"Level '{level}' not found in layer with levels {list(raster.children.keys())}")

--- a/src/dvpio/write/image/tiff_writer.py
+++ b/src/dvpio/write/image/tiff_writer.py
@@ -51,7 +51,7 @@ def get_raster(raster: sd.models.Image2DModel | sd.models.Labels2DModel, level: 
         raise ValueError(f"Unknown raster type, {type(raster)}")
 
 
-def _iter_tiles(array: da.Array, tile_shape=(512, 512)) -> Generator[np.ndarray, None, None]:
+def _iter_tiles(array: np.ndarray | da.Array, tile_shape=(512, 512)) -> Generator[np.ndarray, None, None]:
     """Yield (y, x) tiles from a dask array for memory-efficient TIFF writing.
 
     Iterates over all leading dimensions (C, Z, T, ...) and yields tiles
@@ -69,6 +69,8 @@ def _iter_tiles(array: da.Array, tile_shape=(512, 512)) -> Generator[np.ndarray,
         for y in range(0, height, tile_y):
             for x in range(0, width, tile_x):
                 tile = plane[y : y + tile_y, x : x + tile_x]
+                # xr.DataArray can store out-of-memory dask arrays or numpy arrays
+                # ensure that numpy is returned.
                 if isinstance(tile, da.Array):
                     tile = tile.compute()
                 yield tile

--- a/src/dvpio/write/image/tiff_writer.py
+++ b/src/dvpio/write/image/tiff_writer.py
@@ -100,7 +100,7 @@ def write_ome_tiff(
 
     Returns
     -------
-    Writes an `OME-TIFF` image of the form ... to disk
+    Writes an `OME-TIFF` image to `path`
 
     Example
     -------
@@ -111,7 +111,7 @@ def write_ome_tiff(
         write_ome_tiff(path, sdata["image"])
 
         # Write a multiscale image at a lower resolution level
-        write_ome_tiff(path, sdata["image"], level="scale2")
+        write_ome_tiff(path, sdata["multiscale_image"], level="scale2")
 
     """
     sd.models.Image2DModel.validate(image)

--- a/tests/write/image/test_tiff_writer.py
+++ b/tests/write/image/test_tiff_writer.py
@@ -1,0 +1,46 @@
+from typing import Any
+
+import dask.array as da
+import numpy as np
+import pytest
+import spatialdata as sd
+import xarray as xr
+
+from dvpio.write.image.tiff_writer import get_raster
+
+
+@pytest.fixture
+def sdata() -> sd.SpatialData:
+    sdata = sd.datasets.blobs(length=513)
+    assert "blobs_image" in sdata
+    assert "blobs_multiscale_image" in sdata
+    return sdata
+
+
+@pytest.fixture
+def image(sdata: sd.SpatialData) -> xr.DataArray:
+    return sdata.images["blobs_image"]
+
+
+@pytest.fixture
+def multiscale_image(sdata: sd.SpatialData) -> xr.DataTree:
+    return sdata.images["blobs_multiscale_image"]
+
+
+class TestGetRaster:
+    def test_get_raster__dataarray(self, image: xr.DataTree) -> None:
+        """Test that get_raster returns a data array"""
+        result = get_raster(image)
+        assert isinstance(result, xr.DataArray)
+
+    @pytest.mark.parametrize("level", ["scale1", "scale2", "scale3"])
+    def test_get_raster__datatree(self, image: xr.DataTree, level: str) -> None:
+        """Test that get_raster returns a data array"""
+        result = get_raster(image, level=level)
+        assert isinstance(result, xr.DataArray)
+
+    @pytest.mark.parametrize("image", [np.zeros(shape=(512, 512)), da.zeros(shape=(512, 512))])
+    def test_get_raster__raises(self, image: Any) -> None:
+        """Test that get_raster raisese for unknown data types"""
+        with pytest.raises(ValueError):
+            _ = get_raster(image)

--- a/tests/write/image/test_tiff_writer.py
+++ b/tests/write/image/test_tiff_writer.py
@@ -42,10 +42,16 @@ class TestGetRaster:
         assert isinstance(result, xr.DataArray)
 
     @pytest.mark.parametrize("image", [np.zeros(shape=(512, 512)), da.zeros(shape=(512, 512))])
-    def test_get_raster__raises(self, image: Any) -> None:
+    def test_get_raster__raises_value_error(self, image: Any) -> None:
         """Test that get_raster raisese for unknown data types"""
         with pytest.raises(ValueError):
             _ = get_raster(image)
+
+    @pytest.mark.parametrize("key", "non-existent")
+    def test_get_raster__raises_key_error(self, multiscale_image: Any, key: str) -> None:
+        """Test that get_raster raisese for unknown data types"""
+        with pytest.raises(KeyError):
+            _ = get_raster(multiscale_image, level=key)
 
 
 class TestIterTilesGenerator:

--- a/tests/write/image/test_tiff_writer.py
+++ b/tests/write/image/test_tiff_writer.py
@@ -1,12 +1,14 @@
+from pathlib import Path
 from typing import Any, Literal
 
 import dask.array as da
 import numpy as np
 import pytest
 import spatialdata as sd
+import tifffile as tiff
 import xarray as xr
 
-from dvpio.write.image.tiff_writer import _iter_tiles, get_raster
+from dvpio.write.image.tiff_writer import _iter_tiles, get_raster, write_ome_tiff
 
 
 @pytest.fixture
@@ -97,3 +99,40 @@ class TestIterTilesGenerator:
         tiles = list(iterator)
 
         assert all(tile.shape == reference_shape for tile, reference_shape in zip(tiles, resulting_shapes, strict=True))
+
+
+class TestWriteOmeTiff:
+    @pytest.fixture
+    def image_path(self, tmp_path) -> Path:
+        return tmp_path / "image.tiff"
+
+    @pytest.mark.parametrize("tile_shape", [(256, 256), (512, 512), (1024, 1024)])
+    def test_write_ome_tiff__dataarray(
+        self, image_path, image: sd.models.Image2DModel, tile_shape: tuple[int, int]
+    ) -> None:
+        write_ome_tiff(image_path, image, tile_shape=tile_shape)
+
+        new_image = tiff.imread(image_path)
+
+        assert np.array_equal(new_image, image.data.compute())
+
+    @pytest.mark.parametrize("tile_shape", [(256, 256), (512, 512), (1024, 1024)])
+    @pytest.mark.parametrize("level", ["scale0", "scale1", "scale2"])
+    def test_write_ome_tiff__datatree(
+        self, image_path, multiscale_image: sd.models.Image2DModel, level: str, tile_shape: tuple[int, int]
+    ) -> None:
+        write_ome_tiff(image_path, multiscale_image, level=level, tile_shape=tile_shape)
+
+        new_image = tiff.imread(image_path)
+
+        # Get image at correct resolution
+        ref_image = (
+            multiscale_image.get(key=level)
+            .to_dataset()
+            .to_array(dim="variable")
+            .drop_vars("variable")
+            .squeeze()
+            .data.compute()
+        )
+
+        assert np.array_equal(new_image, ref_image)

--- a/tests/write/image/test_tiff_writer.py
+++ b/tests/write/image/test_tiff_writer.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, Literal
 
 import dask.array as da
 import numpy as np
@@ -6,7 +6,7 @@ import pytest
 import spatialdata as sd
 import xarray as xr
 
-from dvpio.write.image.tiff_writer import get_raster
+from dvpio.write.image.tiff_writer import _iter_tiles, get_raster
 
 
 @pytest.fixture
@@ -44,3 +44,56 @@ class TestGetRaster:
         """Test that get_raster raisese for unknown data types"""
         with pytest.raises(ValueError):
             _ = get_raster(image)
+
+
+class TestIterTilesGenerator:
+    @pytest.mark.parametrize("array_type", ["dask", "numpy"])
+    @pytest.mark.parametrize(
+        ("array_shape", "resulting_shapes"),
+        [
+            # Tile: y, x
+            # Tile order: y, x
+            ((512, 512), [(512, 512)]),
+            ((1024, 1024), [(512, 512), (512, 512), (512, 512), (512, 512)]),
+            ((1023, 1024), [(512, 512), (512, 512), (511, 512), (511, 512)]),
+            (
+                # 3 channels x Single tile/channel
+                (3, 1, 512),
+                [
+                    (1, 512),
+                    (1, 512),
+                    (1, 512),
+                ],
+            ),
+            (
+                # 2 Z-stacks x 3 channels x 1 tile/channel
+                (2, 3, 1, 512),
+                [
+                    (1, 512),
+                    (1, 512),
+                    (1, 512),
+                    (1, 512),
+                    (1, 512),
+                    (1, 512),
+                ],
+            ),
+        ],
+        ids=("1-chunk", "4-chunks", "4-chunks-asymmetric", "multiple-channels", "multiple-channels-z-stacks"),
+    )
+    def test__iter_tiles(
+        self, array_shape: np.ndarray, resulting_shapes: list[tuple], array_type: Literal["dask", "numpy"]
+    ) -> None:
+        """Test that iter tiles returns tiles in the order expected by tifffile"""
+        # Setup dummy image
+        image = np.zeros(shape=array_shape)
+        if array_type == "dask":
+            image = da.array(image)
+        elif array_type == "numpy":
+            image = image
+        else:
+            raise ValueError("Unexpected image type")
+
+        iterator = _iter_tiles(array=image, tile_shape=(512, 512))
+        tiles = list(iterator)
+
+        assert all(tile.shape == reference_shape for tile, reference_shape in zip(tiles, resulting_shapes, strict=True))

--- a/tests/write/image/test_tiff_writer.py
+++ b/tests/write/image/test_tiff_writer.py
@@ -26,7 +26,9 @@ def image(sdata: sd.SpatialData) -> xr.DataArray:
 
 @pytest.fixture
 def multiscale_image(sdata: sd.SpatialData) -> xr.DataTree:
-    return sdata.images["blobs_multiscale_image"]
+    multiscale_image = sdata.images["blobs_multiscale_image"]
+    assert all(scale in multiscale_image.children for scale in ("scale0", "scale1", "scale2"))
+    return multiscale_image
 
 
 class TestGetRaster:
@@ -35,7 +37,7 @@ class TestGetRaster:
         result = get_raster(image)
         assert isinstance(result, xr.DataArray)
 
-    @pytest.mark.parametrize("level", ["scale1", "scale2", "scale3"])
+    @pytest.mark.parametrize("level", ["scale1", "scale2", "scale3", None])
     def test_get_raster__datatree(self, image: xr.DataTree, level: str) -> None:
         """Test that get_raster returns a data array"""
         result = get_raster(image, level=level)
@@ -123,7 +125,7 @@ class TestWriteOmeTiff:
         assert np.array_equal(new_image, image.data.compute())
 
     @pytest.mark.parametrize("tile_shape", [(256, 256), (512, 512), (1024, 1024)])
-    @pytest.mark.parametrize("level", ["scale0", "scale1", "scale2"])
+    @pytest.mark.parametrize("level", ["scale0", "scale1", "scale2", None])
     def test_write_ome_tiff__datatree(
         self, image_path, multiscale_image: sd.models.Image2DModel, level: str, tile_shape: tuple[int, int]
     ) -> None:
@@ -132,13 +134,7 @@ class TestWriteOmeTiff:
         new_image = tiff.imread(image_path)
 
         # Get image at correct resolution
-        ref_image = (
-            multiscale_image.get(key=level)
-            .to_dataset()
-            .to_array(dim="variable")
-            .drop_vars("variable")
-            .squeeze()
-            .data.compute()
-        )
+        ref_image_multiscale = get_raster(multiscale_image, level=level)
+        ref_image = ref_image_multiscale.data.compute()
 
         assert np.array_equal(new_image, ref_image)


### PR DESCRIPTION
Write (OME) `tiff` images with an out-of-memory process. 


## Dependencies
Adds dependency `ome-types` to validate metadata to be compatible with OME schema. 

## Package structure
This brings up some questions about the package structure 
The read structure is `dvpio.read.<modality = image/shapes/omics>.function`

But the current structure for the write functionalities is 
`dvpio.write.function`
which is weird. 
