### PR TITLE
Refactor `write_lmd` function

### DIFF
--- a/src/dvpio/write/lmd_writer.py
+++ b/src/dvpio/write/lmd_writer.py
@@ -2,10 +2,9 @@ import os
 
 import lmd.lib as pylmd
 import numpy as np
-import shapely
 import spatialdata as sd
 
-from dvpio.read.shapes.geometry import apply_transformation
+from dvpio.read.shapes.geometry import affine_matrix_to_shapely, apply_transformation
 
 
 def write_lmd(
@@ -106,14 +105,10 @@ def write_lmd(
         calibration_points[["x", "y"]].to_dask_array().compute(), affine_transformation
     )
 
-    annotation_transformed = annotation["geometry"].apply(
-        lambda shape: shapely.transform(
-            shape,
-            transformation=lambda geom: apply_transformation(geom, affine_transformation),
-        )
-    )
+    shapely_affine_transformation = affine_matrix_to_shapely(affine_matrix=affine_transformation)
+    transformed_shapes = annotation.geometry.affine_transform(shapely_affine_transformation)
 
-    annotation_transformed = annotation.assign(geometry=annotation_transformed)
+    annotation_transformed = annotation.assign(geometry=transformed_shapes)
 
     # Load annotation and optional columns
     collection.load_geopandas(

--- a/src/dvpio/write/lmd_writer.py
+++ b/src/dvpio/write/lmd_writer.py
@@ -91,8 +91,7 @@ def write_lmd(
         raise ValueError(f"Path {path} exists and overwrite is False")
 
     # Create pylmd collection
-    collection = pylmd.Collection(orientation_transform=np.eye(2))
-    collection.scale = 1
+    collection = pylmd.Collection(orientation_transform=np.eye(2), scale=1)
 
     # Transform annotation to leica coordinate system based on transformation
     if affine_transformation is None:

--- a/tests/write/test_lmd_writer.py
+++ b/tests/write/test_lmd_writer.py
@@ -47,6 +47,24 @@ def test_write_lmd(
     )
 
 
+def test_write_lmd__raises_to_few_points(
+    tmp_path,
+    dummy_data,
+) -> None:
+    path = tmp_path / "test.xml"
+    gdf, _ = dummy_data
+    # To few calibration points (at least 3)
+    calibration_points = PointsModel.parse(np.array([[0, 0], [1, 0]]))
+
+    with pytest.raises(ValueError, match="There must be at least 3 points"):
+        write_lmd(
+            path=path,
+            annotation=gdf,
+            calibration_points=calibration_points,
+            overwrite=True,
+        )
+
+
 @pytest.mark.parametrize(
     ["annotation_name_column", "annotation_well_column", "custom_attribute_columns"],
     [


### PR DESCRIPTION
Mirror changes of `read_lmd` function and use `geopandas.GeoDataFrame.affine_transform` to increase robustness. 

Further add another test and make a minor refactor that improves the readability of the code. 