### PR TITLE
Remove `switch_orientation` parameter

### DIFF
--- a/src/dvpio/read/shapes/lmd_reader.py
+++ b/src/dvpio/read/shapes/lmd_reader.py
@@ -114,7 +114,6 @@ def read_lmd(
     calibration_points_image: PointsModel,
     transformation_type: Literal["similarity", "affine", "euclidean"] = "similarity",
     precision: int | None = 6,
-    switch_orientation: bool = False,
 ) -> ShapesModel:
     """Read and parse LMD-formatted masks for the use in spatialdata
 
@@ -141,10 +140,6 @@ def read_lmd(
     precision
         Default 6. Rounding of affine transformation matrix, which can be necessary for numerical stability of shape transformations.
         Passing `None` skips rounding.
-    switch_orientation
-        Per default, LMD is working in a (x, y) coordinate system while the image coordinates are in a (row=y, col=x)
-        coordinate system. If True, transform the coordinate systems by mirroring the coordinate system at the
-        main diagonal.
 
     Returns
     -------
@@ -182,12 +177,5 @@ def read_lmd(
         transformation_type=transformation_type,
         precision=precision,
     )
-
-    if switch_orientation:
-        # Transformation switches x/y coordinates (mirror at main diagonal)
-        switch_axes = lambda geom: geom @ np.array([[0, 1], [1, 0]])
-        transformed_shapes["geometry"] = transformed_shapes["geometry"].apply(
-            lambda geom: shapely.transform(geom, transformation=switch_axes)
-        )
 
     return transformed_shapes

--- a/tests/read/shapes/test_lmd_reader.py
+++ b/tests/read/shapes/test_lmd_reader.py
@@ -44,7 +44,7 @@ def test_transform_shapes() -> None:
     ],
 )
 def test_read_lmd(path: str, calibration_points: NDArray[np.float64], ground_truth_path: str) -> None:
-    lmd_shapes = read_lmd(path, calibration_points, switch_orientation=False, precision=3)
+    lmd_shapes = read_lmd(path, calibration_points, precision=3)
     lmd_centroids = _get_centroid_xy(lmd_shapes["geometry"])
 
     ground_truth = gpd.read_file(ground_truth_path)
@@ -70,7 +70,7 @@ def test_read_lmd(path: str, calibration_points: NDArray[np.float64], ground_tru
     ],
 )
 def test_read_lmd_transformation(path: str, calibration_points: NDArray[np.float64], ground_truth_path: str) -> None:
-    lmd_shapes = read_lmd(path, calibration_points, switch_orientation=False, precision=3)
+    lmd_shapes = read_lmd(path, calibration_points, precision=3)
 
     assert "to_lmd" in lmd_shapes.attrs.get("transform")
     assert isinstance(lmd_shapes.attrs.get("transform").get("to_lmd"), BaseTransformation)


### PR DESCRIPTION
This is already covered by the automatic computation of the affine transformation between image + shape coordinate system. The parameter is `False` per default and remains largely unused. 


