### PR TITLE
Enable RGB tiff storage

### DIFF
--- a/src/dvpio/write/image/tiff_writer.py
+++ b/src/dvpio/write/image/tiff_writer.py
@@ -51,6 +51,21 @@ def get_raster(raster: sd.models.Image2DModel | sd.models.Labels2DModel, level: 
         raise ValueError(f"Unknown raster type, {type(raster)}")
 
 
+def _check_is_rgb(image: sd.models.Image2DModel) -> bool:
+    """Check if an image is an RGB
+
+    Checks if the channel names represent typical aliases for RGB images ("r"/"red", "g"/"green", "b"/"blue")
+
+    References
+    ----------
+    - https://github.com/cgohlke/tifffile
+    """
+    RGB_ALIASES = ({"r", "g", "b"}, {"red", "green", "blue"})
+    channel_names = {str(c).lower() for c in sd.models.get_channel_names(image)}
+
+    return any(channel_names == rgb_alias for rgb_alias in RGB_ALIASES)
+
+
 def _iter_tiles(array: da.Array, tile_shape=(512, 512)) -> Generator[np.ndarray, None, None]:
     """Yield (y, x) tiles from a dask array for memory-efficient TIFF writing.
 
@@ -80,6 +95,8 @@ def write_ome_tiff(
     metadata: dict[str, Any] | None = None,
     tile_shape: tuple[int, int] = (1024, 1024),
     level: str | None = None,
+    *,
+    rgb: bool | None = None,
 ) -> None:
     """Export image data to ome-tiff
 
@@ -98,6 +115,8 @@ def write_ome_tiff(
     level
         Level in mulitscale image to write. If `None`, defaults to highest level. Is ignored for
         single-scale images.
+    rgb
+        Whether the image is RGB or grayscale. If `None`, infers the image type from the channel names.
 
     Returns
     -------
@@ -117,6 +136,11 @@ def write_ome_tiff(
     """
     sd.models.Image2DModel().validate(image)
 
+    # Autodetect RGB images if `rgb=None`
+    if rgb is None:
+        rgb = _check_is_rgb(image)
+    photometric_type = "rgb" if rgb else "minisblack"
+
     image = get_raster(image, level=level)
     metadata = OME(**metadata).to_xml() if metadata is not None else None
 
@@ -126,7 +150,7 @@ def write_ome_tiff(
             shape=image.data.shape,
             dtype=image.data.dtype,
             tile=tile_shape,
-            photometric="minisblack",
+            photometric=photometric_type,
             subifds=None,
             metadata=None,
         )

--- a/src/dvpio/write/image/tiff_writer.py
+++ b/src/dvpio/write/image/tiff_writer.py
@@ -140,8 +140,7 @@ def write_ome_tiff(
     sd.models.Image2DModel().validate(image)
 
     # Autodetect RGB images if `rgb=None`
-    if rgb is None:
-        rgb = _is_rgb(image)
+    rgb = rgb or _is_rgb(image)
     photometric_type = "rgb" if rgb else "minisblack"
 
     image = get_raster(image, level=level)

--- a/src/dvpio/write/image/tiff_writer.py
+++ b/src/dvpio/write/image/tiff_writer.py
@@ -51,7 +51,7 @@ def get_raster(raster: sd.models.Image2DModel | sd.models.Labels2DModel, level: 
         raise ValueError(f"Unknown raster type, {type(raster)}")
 
 
-def _check_is_rgb(image: sd.models.Image2DModel) -> bool:
+def _is_rgb(image: sd.models.Image2DModel) -> bool:
     """Check if an image is an RGB
 
     Checks if the channel names represent typical aliases for RGB images ("r"/"red", "g"/"green", "b"/"blue")
@@ -138,7 +138,7 @@ def write_ome_tiff(
 
     # Autodetect RGB images if `rgb=None`
     if rgb is None:
-        rgb = _check_is_rgb(image)
+        rgb = _is_rgb(image)
     photometric_type = "rgb" if rgb else "minisblack"
 
     image = get_raster(image, level=level)

--- a/tests/write/image/test_tiff_writer.py
+++ b/tests/write/image/test_tiff_writer.py
@@ -8,7 +8,7 @@ import spatialdata as sd
 import tifffile as tiff
 import xarray as xr
 
-from dvpio.write.image.tiff_writer import _check_is_rgb, _iter_tiles, get_raster, write_ome_tiff
+from dvpio.write.image.tiff_writer import _is_rgb, _iter_tiles, get_raster, write_ome_tiff
 
 
 @pytest.fixture
@@ -109,7 +109,7 @@ class TestIterTilesGenerator:
         assert all(tile.shape == reference_shape for tile, reference_shape in zip(tiles, resulting_shapes, strict=True))
 
 
-class TestCheckIsRGB:
+class TestIsRGB:
     @pytest.fixture(
         params=[
             {"channel_names": ["r", "g", "b"]},
@@ -127,13 +127,13 @@ class TestCheckIsRGB:
 
         return image_rgb.assign_coords(coords={"c": request.param["channel_names"]})
 
-    def test__check_is_rgb__rgb_image(self, rgb_image: sd.models.Image2DModel) -> None:
+    def test__is_rgb__rgb_image(self, rgb_image: sd.models.Image2DModel) -> None:
         """Test that _check_is_rgb returns True if RGB image is passed"""
-        assert _check_is_rgb(rgb_image)
+        assert _is_rgb(rgb_image)
 
-    def test__check_is_rgb__grayscale_image(self, image: sd.models.Image2DModel) -> None:
+    def test__is_rgb__grayscale_image(self, image: sd.models.Image2DModel) -> None:
         """Test that _check_is_rgb returns True if RGB image is passed"""
-        assert not _check_is_rgb(image)
+        assert not _is_rgb(image)
 
 
 class TestWriteOmeTiff:

--- a/tests/write/image/test_tiff_writer.py
+++ b/tests/write/image/test_tiff_writer.py
@@ -8,7 +8,7 @@ import spatialdata as sd
 import tifffile as tiff
 import xarray as xr
 
-from dvpio.write.image.tiff_writer import _iter_tiles, get_raster, write_ome_tiff
+from dvpio.write.image.tiff_writer import _check_is_rgb, _iter_tiles, get_raster, write_ome_tiff
 
 
 @pytest.fixture
@@ -109,10 +109,45 @@ class TestIterTilesGenerator:
         assert all(tile.shape == reference_shape for tile, reference_shape in zip(tiles, resulting_shapes, strict=True))
 
 
+class TestCheckIsRGB:
+    @pytest.fixture(
+        params=[
+            {"channel_names": ["r", "g", "b"]},
+            {"channel_names": ["R", "G", "B"]},
+            {"channel_names": ["red", "green", "blue"]},
+            {"channel_names": ["Red", "Green", "Blue"]},
+        ]
+    )
+    def rgb_image(self, image: sd.models.Image2DModel, request) -> sd.models.Image2DModel:
+        """Create an rgb image from a spatialdata image model"""
+        dim_shapes = dict(zip(image.dims, image.shape, strict=True))
+        assert dim_shapes["c"] == 3
+
+        image_rgb = image.copy()
+
+        return image_rgb.assign_coords(coords={"c": request.param["channel_names"]})
+
+    def test__check_is_rgb__rgb_image(self, rgb_image: sd.models.Image2DModel) -> None:
+        """Test that _check_is_rgb returns True if RGB image is passed"""
+        assert _check_is_rgb(rgb_image)
+
+    def test__check_is_rgb__grayscale_image(self, image: sd.models.Image2DModel) -> None:
+        """Test that _check_is_rgb returns True if RGB image is passed"""
+        assert not _check_is_rgb(image)
+
+
 class TestWriteOmeTiff:
     @pytest.fixture
     def image_path(self, tmp_path) -> Path:
         return tmp_path / "image.tiff"
+
+    @pytest.fixture
+    def image_3channel(self, image) -> Path:
+        # Validate that there are 3 channels
+        dim_shapes = dict(zip(image.dims, image.shape, strict=True))
+        assert dim_shapes["c"] == 3
+        assert sd.models.get_channel_names(image) == [0, 1, 2]
+        return image.copy()
 
     @pytest.mark.parametrize("tile_shape", [(256, 256), (512, 512), (1024, 1024)])
     def test_write_ome_tiff__dataarray(
@@ -138,3 +173,17 @@ class TestWriteOmeTiff:
         ref_image = ref_image_multiscale.data.compute()
 
         assert np.array_equal(new_image, ref_image)
+
+    @pytest.mark.parametrize("rgb", [True, False, None])
+    def test_write_ome_tiff__test_rgb(
+        self, image_path, image_3channel: sd.models.Image2DModel, rgb: bool | None
+    ) -> None:
+        write_ome_tiff(image_path, image_3channel, rgb=rgb)
+
+        with tiff.TiffFile(image_path, mode="r") as img:
+            photometric_type = img.pages[0].photometric.name.lower()
+
+        if rgb is True:
+            assert photometric_type == "rgb"
+        else:
+            assert photometric_type == "minisblack"


### PR DESCRIPTION
Tiff files are stored differently depending on whether they represent RGB images or microscopy grayscale images. 

Add `rgb` parameter to `write_ome_tiff` function signature to properly store RGB images

If `None`, auto-infers image type from channel names in sdata object. Passing `rgb=True/False` overwrites this auto detection.