### PR TITLE
Revert python3.14 support

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -36,9 +36,7 @@ jobs:
           - os: ubuntu-latest
             python: "3.13"
           - os: ubuntu-latest
-            python: "3.14"
-          - os: ubuntu-latest
-            python: "3.14"
+            python: "3.13"
             pip-flags: "--pre"
             name: PRE-RELEASE DEPENDENCIES
 

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,9 +1,9 @@
 # https://docs.readthedocs.io/en/stable/config-file/v2.html
 version: 2
 build:
-  os: ubuntu-20.04
+  os: ubuntu-24.04
   tools:
-    python: "3.10"
+    python: "3.13"
   apt_packages:
     - libssh2-1
     - libssh2-1.dev

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,14 +14,13 @@ maintainers = [
 authors = [
   { name = "Lucas Diedrich" },
 ]
-requires-python = ">=3.10"
+requires-python = ">=3.10,<3.14"
 classifiers = [
   "Programming Language :: Python :: 3 :: Only",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
-  "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
   "alphabase",
@@ -81,7 +80,7 @@ scripts.clean = "git clean -fdX -- {args:docs}"
 [tool.hatch.envs.hatch-test]
 features = [ "test" ]
 matrix = [
-  { python = [ "3.10", "3.11", "3.12", "3.13", "3.14" ] },
+  { python = [ "3.10", "3.11", "3.12", "3.13" ] },
 ]
 
 [tool.hatch.metadata]


### PR DESCRIPTION
Currently, python3.14 is unstable due to 2 issues with the pylmd dependency:
- https://github.com/MannLabs/py-lmd/issues/65
- pylmd does not support the latest numpy versions. 

Revert python 3.14 support for now and address the upstream issues separately. 