### PR TITLE
Refactor/get multiscale image

### DIFF
--- a/src/dvpio/write/image/tiff_writer.py
+++ b/src/dvpio/write/image/tiff_writer.py
@@ -13,7 +13,7 @@ import xarray as xr
 from ome_types import OME
 
 
-def get_raster(raster: sd.models.Image2DModel | sd.models.Labels2DModel, level: str | None = None) -> xr.DataArray:
+def get_raster(raster: sd.models.Image2DModel | sd.models.Labels2DModel, level: int | None = None) -> xr.DataArray:
     """Get raster layer of spatialdata object as :class:`xr.DataArray`
 
     Parameters
@@ -34,6 +34,8 @@ def get_raster(raster: sd.models.Image2DModel | sd.models.Labels2DModel, level: 
         return raster
 
     elif isinstance(raster, xr.DataTree):
+        # Default to highest resolution
+        level = level or 0
         return sd.get_pyramid_levels(raster, n=level)
     else:
         raise ValueError(f"Unknown raster type, {type(raster)}")

--- a/src/dvpio/write/image/tiff_writer.py
+++ b/src/dvpio/write/image/tiff_writer.py
@@ -34,20 +34,21 @@ def get_raster(raster: sd.models.Image2DModel | sd.models.Labels2DModel, level: 
         return raster
 
     elif isinstance(raster, xr.DataTree):
-        # Get first descendant (highest resolution) per default
-        data_at_level = raster.get(key=level) if level is not None else raster.descendants[0]
+        return sd.get_pyramid_levels(raster, n=int(level.replace("scale", "")))
+    #     # Get first descendant (highest resolution) per default
+    #     data_at_level = raster.get(key=level) if level is not None else raster.descendants[0]
 
-        if data_at_level is None:
-            raise KeyError(f"Level '{level}' not found in layer with levels {list(raster.children.keys())}")
+    #     if data_at_level is None:
+    #         raise KeyError(f"Level '{level}' not found in layer with levels {list(raster.children.keys())}")
 
-        return (
-            data_at_level.to_dataset()
-            # xarray introduces a new dimension in which data variable are broadcasted against each other
-            # This dimension is empty for spatialdata.Image2DModels.
-            .to_array(dim="variable")
-            .drop_vars("variable", errors="raise")
-            .squeeze()
-        )
+    #     return (
+    #         data_at_level.to_dataset()
+    #         # xarray introduces a new dimension in which data variable are broadcasted against each other
+    #         # This dimension is empty for spatialdata.Image2DModels.
+    #         .to_array(dim="variable")
+    #         .drop_vars("variable", errors="raise")
+    #         .squeeze()
+    #     )
     else:
         raise ValueError(f"Unknown raster type, {type(raster)}")
 

--- a/src/dvpio/write/image/tiff_writer.py
+++ b/src/dvpio/write/image/tiff_writer.py
@@ -34,21 +34,7 @@ def get_raster(raster: sd.models.Image2DModel | sd.models.Labels2DModel, level: 
         return raster
 
     elif isinstance(raster, xr.DataTree):
-        return sd.get_pyramid_levels(raster, n=int(level.replace("scale", "")))
-    #     # Get first descendant (highest resolution) per default
-    #     data_at_level = raster.get(key=level) if level is not None else raster.descendants[0]
-
-    #     if data_at_level is None:
-    #         raise KeyError(f"Level '{level}' not found in layer with levels {list(raster.children.keys())}")
-
-    #     return (
-    #         data_at_level.to_dataset()
-    #         # xarray introduces a new dimension in which data variable are broadcasted against each other
-    #         # This dimension is empty for spatialdata.Image2DModels.
-    #         .to_array(dim="variable")
-    #         .drop_vars("variable", errors="raise")
-    #         .squeeze()
-    #     )
+        return sd.get_pyramid_levels(raster, n=level)
     else:
         raise ValueError(f"Unknown raster type, {type(raster)}")
 
@@ -98,7 +84,7 @@ def write_ome_tiff(
     image: sd.models.Image2DModel,
     metadata: dict[str, Any] | None = None,
     tile_shape: tuple[int, int] = (1024, 1024),
-    level: str | None = None,
+    level: int | None = None,
     *,
     rgb: bool | None = None,
 ) -> None:
@@ -117,7 +103,7 @@ def write_ome_tiff(
     tile_shape
         (height, width) of each tile written to the TIFF image. Tile shape must be a multiple of 16.
     level
-        Level in mulitscale image to write. If `None`, defaults to highest level. Is ignored for
+        Integer level in mulitscale image to write. If `None`, defaults to highest level. Is ignored for
         single-scale images.
     rgb
         Whether the image is RGB or grayscale. If `None`, infers the image type from the channel names.
@@ -135,7 +121,7 @@ def write_ome_tiff(
         write_ome_tiff(path, sdata["image"])
 
         # Write a multiscale image at a lower resolution level
-        write_ome_tiff(path, sdata["multiscale_image"], level="scale2")
+        write_ome_tiff(path, sdata["multiscale_image"], level=2)
 
     """
     sd.models.Image2DModel().validate(image)

--- a/tests/write/image/test_tiff_writer.py
+++ b/tests/write/image/test_tiff_writer.py
@@ -49,12 +49,6 @@ class TestGetRaster:
         with pytest.raises(ValueError):
             _ = get_raster(image)
 
-    @pytest.mark.parametrize("key", "non-existent")
-    def test_get_raster__raises_key_error(self, multiscale_image: Any, key: str) -> None:
-        """Test that get_raster raisese for unknown data types"""
-        with pytest.raises(KeyError):
-            _ = get_raster(multiscale_image, level=key)
-
 
 class TestIterTilesGenerator:
     @pytest.mark.parametrize("array_type", ["dask", "numpy"])
@@ -160,7 +154,7 @@ class TestWriteOmeTiff:
         assert np.array_equal(new_image, image.data.compute())
 
     @pytest.mark.parametrize("tile_shape", [(256, 256), (512, 512), (1024, 1024)])
-    @pytest.mark.parametrize("level", ["scale0", "scale1", "scale2", None])
+    @pytest.mark.parametrize("level", [0, 1, 2, None])
     def test_write_ome_tiff__datatree(
         self, image_path, multiscale_image: sd.models.Image2DModel, level: str, tile_shape: tuple[int, int]
     ) -> None:


### PR DESCRIPTION
Use spatialdata-native function to get pyramid levels. Allows users to specify an integer value instead of the string value (theoretically breaking but there has not been a release yet). Utility function has been part of spatialdata since v0.2.3. 