### PR TITLE
[actions] Introduce auto updates with dependabot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -9,7 +9,6 @@ updates:
       interval: "weekly"
     # Do not pull most recent updates to ensure that security issues get detected
     # This only applies for version updates, i.e. security-relevant releases are immediately applied
-    # https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#cooldown-
     cooldown:
       default-days: 7
     commit-message:

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,17 @@
+# Set update schedule for GitHub Actions
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every week
+      interval: "weekly"
+    # Do not pull most recent updates to ensure that security issues get detected
+    # This only applies for version updates, i.e. security-relevant releases are immediately applied
+    # https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#cooldown-
+    cooldown:
+      default-days: 7
+    commit-message:
+      include: scope
+      prefix: "[dep]"


### PR DESCRIPTION
Automatically update actions with dependabot. Sets a cooldown time of 7 days so that security-relevant bugs in newer action versions can get fixed. 